### PR TITLE
Refactor: Split Docker Compose config for dev/prod separation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 postgres_data/
+docker-compose.prod.yml

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ jspm_packages/
 # Mac / VSCode
 .DS_Store
 .vscode/
+docker-compose.prod.yml

--- a/README.md
+++ b/README.md
@@ -177,12 +177,28 @@ Nous allons construire cette application étape par étape, en commençant par l
   - [ ] Rédiger la documentation finale.
   - [ ] Valider le workflow de déploiement Docker.
 
-### 2. Run with Docker Compose (Recommended)
+### 2. Run with Docker Compose
 
-To build and run all services in detached mode:
+The project uses a split Docker Compose configuration to separate common settings, development specifics, and production overrides.
+
+*   `docker-compose.yml`: Base configuration (services, images, env vars).
+*   `docker-compose.override.yml`: Development overrides (ports, test services). **Loaded automatically**.
+*   `docker-compose.prod.yml`: Production overrides (Traefik labels, networks).
+
+#### Development (Default)
+
+To build and run all services in detached mode for development (loads `base` + `override`):
 
 ```bash
 docker compose up -d --build
+```
+
+#### Production
+
+To run in production mode (loads `base` + `prod`, ignoring dev overrides):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ```
 
 **Note sur la persistance des données PostgreSQL**: Les données de la base de données PostgreSQL sont désormais stockées dans un répertoire local (`./postgres_data`) à côté du fichier `docker-compose.yml`. Cela facilite la sauvegarde et la gestion directe des données de la base de données pour les environnements de développement.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,30 @@
+services:
+  # db:
+  #   ports:
+  #     - "5432:5432"
+
+  tests-backend:
+    build:
+      context: .
+      dockerfile: api/Dockerfile.test
+    container_name: nikoniko_tests_backend
+    volumes:
+      - ./test-results:/src/TestResults # Mount test results directory
+
+  backend:
+    ports:
+      - "5000:8080"
+    depends_on:
+      tests-backend:
+        condition: service_completed_successfully
+
+  notifications:
+    ports:
+      - "5001:8080" # Map to an external port
+    depends_on:
+      tests-backend:
+        condition: service_completed_successfully
+
+  frontend:
+    ports:
+      - "3000:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,4 @@
 services:
-  tests-backend:
-    build:
-      context: .
-      dockerfile: api/Dockerfile.test
-    container_name: nikoniko_tests_backend
-    volumes:
-      - ./test-results:/src/TestResults # Mount test results directory
-
   # db:
   #   image: postgres:16
   #   container_name: nikoniko_db
@@ -16,8 +8,6 @@ services:
   #     - POSTGRES_PASSWORD=nikoniko
   #   volumes:
   #     - ./postgres_data:/var/lib/postgresql/data # Bind mount to a local directory for backup
-  #   ports:
-  #     - "5432:5432"
   #   healthcheck:
   #     test: ["CMD-SHELL", "pg_isready -U nikoniko -d nikoniko"]
   #     interval: 10s
@@ -49,16 +39,12 @@ services:
       - Authentication__FrontendRedirectUrl=${FRONTEND_REDIRECT_URL}
       - SignalRService__BaseUrl=http://nikoniko_notifications:8080 # SignalR Service URL for backend
       - SUPER_ADMINS=${SUPER_ADMINS}
-    ports:
-      - "5000:8080"
     healthcheck:
       test: ["CMD-SHELL", "curl -fL http://localhost:8080/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
-    depends_on:
-      tests-backend:
-        condition: service_completed_successfully
+
   notifications: # New SignalR Service
     build:
       context: .
@@ -71,27 +57,17 @@ services:
       - Authentication__Jwt__Issuer=NikoNiko
       - Authentication__Jwt__Audience=NikoNikoClient
       - Authentication__Jwt__Key=${JWT_KEY}
-    ports:
-      - "5001:8080" # Map to an external port
     healthcheck:
       test: ["CMD-SHELL", "curl -fL http://localhost:8080/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
-    depends_on:
-      tests-backend:
-        condition: service_completed_successfully
-    # depends_on:
-    #   db: # SignalR might need DB access for user management etc.
-    #     condition: service_healthy
 
   frontend:
     build:
       context: ./app/frontend
       dockerfile: Dockerfile
     container_name: nikoniko_frontend
-    ports:
-      - "3000:80"
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
- Split docker-compose.yml into base, override (dev), and prod configurations.
- Added docker-compose.override.yml for local development settings (ports, tests).
- Updated .gitignore and .dockerignore to exclude docker-compose.prod.yml.
- Updated README.md with new usage instructions.