### PR TITLE
fix(issue-7): Use client timezone offset to validate mood entry date

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerTests.cs
@@ -112,4 +112,89 @@ public class MoodEntriesControllerTests
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, getMoodEntriesResponse.StatusCode);
     }
+
+    [Fact]
+    public async Task CreateMoodEntry_AheadOfUtc_ReturnsCreated()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Tokyo User");
+        var team = await application.CreateTeam("Global Team", user.Id);
+
+        // Create sprint covering "tomorrow"
+        var createSprintDto = new CreateSprintDto
+        {
+            Name = "Sprint 1",
+            TeamId = team.Id,
+            StartDate = DateTime.UtcNow.Date.AddDays(-1),
+            EndDate = DateTime.UtcNow.Date.AddDays(5)
+        };
+        var sprintResp = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
+        sprintResp.EnsureSuccessStatusCode();
+        var sprint = await sprintResp.Content.ReadFromJsonAsync<SprintDto>();
+
+        // Scenario: User is in a timezone ahead of UTC (e.g. UTC+24 for test simplicity)
+        // They try to post a mood for "Tomorrow" (relative to UTC), which is "Today" for them.
+        // Condition: entryDate <= UtcNow + Offset
+        
+        var entryDate = DateTime.UtcNow.Date.AddDays(1); // "Tomorrow" UTC
+        var offsetMinutes = 24 * 60; // +24 hours offset
+        
+        var createMoodEntryDto = new CreateMoodEntryDto
+        {
+            SprintId = sprint.Id,
+            UserId = user.Id,
+            Mood = MoodType.Happy,
+            Date = entryDate,
+            TimezoneOffset = offsetMinutes
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/moodentries", createMoodEntryDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateMoodEntry_BehindUtc_ReturnsBadRequest()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("NY User");
+        var team = await application.CreateTeam("Global Team", user.Id);
+
+        var createSprintDto = new CreateSprintDto
+        {
+            Name = "Sprint 1",
+            TeamId = team.Id,
+            StartDate = DateTime.UtcNow.Date.AddDays(-1),
+            EndDate = DateTime.UtcNow.Date.AddDays(5)
+        };
+        var sprintResp = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
+        sprintResp.EnsureSuccessStatusCode();
+        var sprint = await sprintResp.Content.ReadFromJsonAsync<SprintDto>();
+
+        // Scenario: User is in a timezone behind UTC (e.g. UTC-5)
+        // They try to post a mood for "Tomorrow" (relative to UTC).
+        // Condition: entryDate > UtcNow + Offset
+        
+        var entryDate = DateTime.UtcNow.Date.AddDays(1); // "Tomorrow" UTC
+        var offsetMinutes = -300; // -5 hours offset (NY)
+        
+        var createMoodEntryDto = new CreateMoodEntryDto
+        {
+            SprintId = sprint.Id,
+            UserId = user.Id,
+            Mood = MoodType.Happy,
+            Date = entryDate,
+            TimezoneOffset = offsetMinutes
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/moodentries", createMoodEntryDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }

--- a/api/NikoNiko.Api/Controllers/MoodEntriesController.cs
+++ b/api/NikoNiko.Api/Controllers/MoodEntriesController.cs
@@ -148,9 +148,14 @@ public class MoodEntriesController : ControllerBase
 
         var entryDate = createMoodEntryDto.Date?.ToUniversalTime().Date ?? DateTime.UtcNow.Date;
 
-        if (entryDate > DateTime.UtcNow.Date)
+        // Calculate the user's local date based on the provided timezone offset.
+        // We add the offset (in minutes) to UtcNow to get the user's local time.
+        // For example, Tokyo (UTC+9) has an offset of +540. UtcNow + 540 minutes = Local Time.
+        var userLocalNow = DateTime.UtcNow.AddMinutes(createMoodEntryDto.TimezoneOffset);
+
+        if (entryDate > userLocalNow.Date)
         {
-            return BadRequest("Mood entry date cannot be in the future.");
+            return BadRequest("Mood entry date cannot be in the future (relative to your local time).");
         }
 
         if (entryDate < sprint.StartDate.Date)

--- a/api/NikoNiko.Core/DTOs/Mood/CreateMoodEntryDto.cs
+++ b/api/NikoNiko.Core/DTOs/Mood/CreateMoodEntryDto.cs
@@ -31,4 +31,10 @@ public class CreateMoodEntryDto
     /// The date of the mood entry. Defaults to the current date if not provided.
     /// </summary>
     public DateTime? Date { get; set; }
+
+    /// <summary>
+    /// The client's timezone offset in minutes from UTC.
+    /// Positive values are East of UTC, negative values are West of UTC (e.g., +60 for UTC+1).
+    /// </summary>
+    public int TimezoneOffset { get; set; }
 }

--- a/app/frontend/src/models/CreateMood.ts
+++ b/app/frontend/src/models/CreateMood.ts
@@ -5,4 +5,5 @@ export interface CreateMood {
   sprintId: string;
   mood: MoodType;
   date?: string; // Optional date for the mood entry
+  timezoneOffset?: number; // Added to match backend DTO
 }

--- a/app/frontend/src/services/moodService.ts
+++ b/app/frontend/src/services/moodService.ts
@@ -1,9 +1,14 @@
 import api from './api';
 import type { Mood } from '../models/Mood';
 import type { CreateMood } from '../models/CreateMood';
+import dayjs from 'dayjs';
 
 export const createMoodEntry = async (moodEntry: CreateMood): Promise<Mood> => {
-  const { data } = await api.post('/moodentries', moodEntry);
+  const payload = {
+    ...moodEntry,
+    timezoneOffset: dayjs().utcOffset()
+  };
+  const { data } = await api.post('/moodentries', payload);
   return data;
 };
 


### PR DESCRIPTION
This allows users in timezones ahead of UTC to post mood entries for their local 'today' even if it is 'tomorrow' in UTC.

Changes:
- Added TimezoneOffset to CreateMoodEntryDto (Backend) and CreateMood interface (Frontend).
- Updated MoodEntriesController validation to calculate user's local date.
- Updated moodService to send dayjs().utcOffset() in the payload.
- Added integration tests for Tokyo and New York scenarios.

closes #7 