### PR TITLE
feat(auth): auto-create team for new users without invitations

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/AuthControllerTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/AuthControllerTests.cs
@@ -36,4 +36,127 @@ public class AuthControllerTests
         Assert.NotNull(isSuperAdminClaim);
         Assert.Equal("true", isSuperAdminClaim.Value, ignoreCase: true);
     }
+
+    [Fact]
+    public async Task SignIn_NewUser_NoInvitation_CreatesTeam()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var client = application.CreateDefaultClient();
+
+        // Act
+        var response = await client.GetAsync("/api/auth/signin-github");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            
+            var user = await dbContext.Users
+                .Include(u => u.TeamUsers)
+                .FirstOrDefaultAsync(u => u.Email == "newtestuser@example.com");
+                
+            Assert.NotNull(user);
+            var team = await dbContext.Teams.FirstOrDefaultAsync(t => t.AdminId == user.Id);
+            Assert.NotNull(team);
+            Assert.Equal("New Test User's Team", team.Name);
+            Assert.Contains(user.TeamUsers, tu => tu.TeamId == team.Id);
+        }
+    }
+
+    [Fact]
+    public async Task SignIn_NewUser_WithInvitation_NoTeamCreated()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var client = application.CreateDefaultClient();
+        
+        // Pre-create a team and an invitation
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var admin = new User { Id = Guid.NewGuid(), Name = "Admin", Email = "admin@example.com", OAuthId = "github|admin" };
+            var team = new Team { Id = Guid.NewGuid(), Name = "Existing Team", AdminId = admin.Id };
+            var invitation = new TeamInvitation 
+            { 
+                Id = Guid.NewGuid(), 
+                TeamId = team.Id, 
+                Token = "test-token", 
+                ExpirationDate = DateTime.UtcNow.AddDays(1),
+                CreatorUserId = admin.Id,
+                Status = "Pending"
+            };
+            dbContext.Users.Add(admin);
+            dbContext.Teams.Add(team);
+            dbContext.TeamInvitations.Add(invitation);
+            await dbContext.SaveChangesAsync();
+        }
+
+        // Act
+        var response = await client.GetAsync("/api/auth/signin-github?invitationToken=test-token");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await dbContext.Users
+                .Include(u => u.TeamUsers)
+                .ThenInclude(tu => tu.Team)
+                .FirstOrDefaultAsync(u => u.Email == "newtestuser@example.com");
+                
+            Assert.NotNull(user);
+            // User should be member of Existing Team
+            Assert.Contains(user.TeamUsers, tu => tu.Team != null && tu.Team.Name == "Existing Team");
+            
+            // User should NOT be admin of any team
+            var userAdminTeams = await dbContext.Teams.Where(t => t.AdminId == user.Id).ToListAsync();
+            Assert.Empty(userAdminTeams);
+        }
+    }
+
+    [Fact]
+    public async Task SignIn_ExistingUser_NoNewTeam()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var client = application.CreateDefaultClient();
+        
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var existingUser = new User 
+            { 
+                Id = Guid.NewGuid(), 
+                Name = "New Test User", 
+                Email = "newtestuser@example.com", 
+                OAuthId = "github|newtestuser" 
+            };
+            dbContext.Users.Add(existingUser);
+            await dbContext.SaveChangesAsync();
+        }
+        
+        int initialTeamCount;
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            initialTeamCount = await dbContext.Teams.CountAsync();
+        }
+
+        // Act
+        var response = await client.GetAsync("/api/auth/signin-github");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var finalTeamCount = await dbContext.Teams.CountAsync();
+            Assert.Equal(initialTeamCount, finalTeamCount);
+        }
+    }
 }

--- a/api/NikoNiko.Api.IntegrationTests/NikoNikoApiTestApplication.cs
+++ b/api/NikoNiko.Api.IntegrationTests/NikoNikoApiTestApplication.cs
@@ -191,6 +191,14 @@ public class NikoNikoApiTestApplication : WebApplicationFactory<Program>
         return (user, client, jwtToken);
     }
 
+    public HttpClient CreateDefaultClient()
+    {
+        return CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+    }
+
     public async Task<Team> CreateTeam(string name, Guid adminId)
     {
         using var scope = Services.CreateScope();

--- a/api/NikoNiko.Api/Controllers/AuthController.cs
+++ b/api/NikoNiko.Api/Controllers/AuthController.cs
@@ -276,6 +276,28 @@ public class AuthController : ControllerBase
 
             _context.Users.Add(user);
             await _context.SaveChangesAsync();
+
+            // Auto-create a team for new users who sign up without an invitation token
+            if (string.IsNullOrEmpty(invitationToken))
+            {
+                var teamName = $"{(string.IsNullOrWhiteSpace(user.Name) ? "My" : user.Name)}'s Team";
+                var newTeam = new Team
+                {
+                    Name = teamName,
+                    AdminId = user.Id
+                };
+
+                var teamUser = new TeamUser
+                {
+                    Team = newTeam,
+                    UserId = user.Id
+                };
+
+                _context.Teams.Add(newTeam);
+                _context.TeamUsers.Add(teamUser);
+                await _context.SaveChangesAsync();
+                _logger.LogInformation("Auto-created team {TeamName} for new user {Email}.", teamName, user.Email);
+            }
         }
         else
         {


### PR DESCRIPTION
- Modify AuthController to detect new sign-ups without an invitation token
- Automatically provision a default team and assign the user as administrator
- Add integration tests covering auto-creation, invitation handling, and existing users
- Fix integration test infrastructure (DataProtection, redirect handling)