### PR TITLE
feat(ux): enhance team admin capabilities, security and ui consistency

### DIFF
--- a/api/NikoNiko.Api/Controllers/TeamsController.cs
+++ b/api/NikoNiko.Api/Controllers/TeamsController.cs
@@ -45,6 +45,7 @@ public class TeamsController : ControllerBase
         var isSuperAdmin = User.HasClaim("is_super_admin", "true");
 
         IQueryable<Team> baseQuery = _context.Teams
+            .Include(t => t.Admin)
             .Include(t => t.Sprints)
             .Include(t => t.TeamUsers)
             .ThenInclude(tu => tu.User);
@@ -60,6 +61,7 @@ public class TeamsController : ControllerBase
                 Id = t.Id,
                 Name = t.Name,
                 AdminId = t.AdminId,
+                AdminName = t.Admin.Name ?? t.Admin.Email,
                 CreatedAt = t.CreatedAt,
                 Sprints = t.Sprints.Select(s => new SprintDto
                 {
@@ -97,6 +99,7 @@ public class TeamsController : ControllerBase
     public async Task<ActionResult<TeamWithSprintsDto>> GetTeam(Guid teamId)
     {
         var team = await _context.Teams
+            .Include(t => t.Admin)
             .Include(t => t.Sprints)
             .Include(t => t.TeamUsers)
             .ThenInclude(tu => tu.User)
@@ -105,6 +108,7 @@ public class TeamsController : ControllerBase
                 Id = t.Id,
                 Name = t.Name,
                 AdminId = t.AdminId,
+                AdminName = t.Admin.Name ?? t.Admin.Email,
                 CreatedAt = t.CreatedAt,
                 Sprints = t.Sprints.Select(s => new SprintDto
                 {
@@ -194,11 +198,15 @@ public class TeamsController : ControllerBase
         _context.TeamUsers.Add(teamUser);
         await _context.SaveChangesAsync();
 
+        // Load admin to get the name
+        await _context.Entry(team).Reference(t => t.Admin).LoadAsync();
+
         var teamDto = new TeamDto
         {
             Id = team.Id,
             Name = team.Name,
             AdminId = team.AdminId,
+            AdminName = team.Admin.Name ?? team.Admin.Email,
             CreatedAt = team.CreatedAt
         };
 

--- a/api/NikoNiko.Api/Controllers/UsersController.cs
+++ b/api/NikoNiko.Api/Controllers/UsersController.cs
@@ -104,6 +104,12 @@ public class UsersController : ControllerBase
     [Authorize(Policy = "SuperAdmin")]
     public async Task<IActionResult> DeleteUser(Guid id)
     {
+        var currentUserIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (Guid.TryParse(currentUserIdString, out var currentUserId) && id == currentUserId)
+        {
+            return BadRequest("You cannot delete your own account.");
+        }
+
         var user = await _context.Users.FindAsync(id);
         if (user == null)
         {

--- a/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
@@ -18,6 +18,10 @@ public class TeamDto
     /// </summary>
     public Guid AdminId { get; set; }
     /// <summary>
+    /// Le nom de l'administrateur de l'équipe.
+    /// </summary>
+    public string AdminName { get; set; } = null!;
+    /// <summary>
     /// La date de création de l'équipe.
     /// </summary>
     public DateTime CreatedAt { get; set; }

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -88,7 +88,7 @@ function App() {
             <Route
               path="/admin"
               element={
-                <ProtectedRoute requiredSuperAdmin={true}>
+                <ProtectedRoute>
                   <Navigate to="/admin/teams" />
                 </ProtectedRoute>
               }
@@ -104,7 +104,7 @@ function App() {
             <Route
               path="/admin/users"
               element={
-                <ProtectedRoute requiredSuperAdmin={true}>
+                <ProtectedRoute>
                   <AdminUsersPage /> {/* To be created */}
                 </ProtectedRoute>
               }
@@ -112,7 +112,7 @@ function App() {
             <Route
               path="/admin/sprints"
               element={
-                <ProtectedRoute requiredSuperAdmin={true}>
+                <ProtectedRoute>
                   <AdminSprintsPage /> {/* To be created */}
                 </ProtectedRoute>
               }

--- a/app/frontend/src/components/AdminTeamListItem.tsx
+++ b/app/frontend/src/components/AdminTeamListItem.tsx
@@ -9,8 +9,9 @@ import {
   ListItem,
   ListItemAvatar,
   ListItemText,
+  Chip,
 } from '@mui/material';
-import { Delete as DeleteIcon, Group as GroupIcon } from '@mui/icons-material';
+import { Delete as DeleteIcon, Group as GroupIcon, Face as FaceIcon } from '@mui/icons-material';
 import type { TeamWithMembersAndSprints } from '../models/Team/TeamWithMembersAndSprints';
 
 interface AdminTeamListItemProps {
@@ -22,9 +23,18 @@ const AdminTeamListItem: React.FC<AdminTeamListItemProps> = ({ team, onDelete })
   return (
     <Paper elevation={2} sx={{ p: 2, mb: 3, display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Typography variant="h6" component="div">
-          {team.name}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Typography variant="h6" component="div">
+            {team.name}
+          </Typography>
+          <Chip
+            icon={<FaceIcon />}
+            label={`Owner: ${team.adminName}`}
+            variant="outlined"
+            size="small"
+            color="primary"
+          />
+        </Box>
         <Button
           variant="outlined"
           color="error"

--- a/app/frontend/src/components/layout/Sidebar.tsx
+++ b/app/frontend/src/components/layout/Sidebar.tsx
@@ -48,9 +48,12 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ open, handleDrawerClose, handleDrawerOpen }) => {
-  const { user, logout, isSuperAdmin } = useAuth();
+  const { user, logout, isSuperAdmin, userTeamRoles } = useAuth();
   const { toggleColorMode, mode } = useColorMode();
   const navigate = useNavigate();
+
+  const isAnyTeamAdmin = Object.values(userTeamRoles).some((role) => role.isAdmin);
+  const showAdminMenu = isSuperAdmin || isAnyTeamAdmin;
 
   const [openAdminMenu, setOpenAdminMenu] = React.useState(false);
 
@@ -113,7 +116,7 @@ const Sidebar: React.FC<SidebarProps> = ({ open, handleDrawerClose, handleDrawer
           </ListItemButton>
         </ListItem>
 
-        {isSuperAdmin && (
+        {showAdminMenu && (
           <>
             <Divider />
             <ListItem disablePadding sx={{ display: 'block' }}>
@@ -140,28 +143,30 @@ const Sidebar: React.FC<SidebarProps> = ({ open, handleDrawerClose, handleDrawer
               </ListItemButton>
               <Collapse in={openAdminMenu} timeout="auto" unmountOnExit>
                 <List component="div" disablePadding>
-                  <ListItem disablePadding sx={{ display: 'block' }}>
-                    <ListItemButton
-                      component={NavLink}
-                      to="/admin/teams"
-                      sx={{
-                        minHeight: 48,
-                        justifyContent: open ? 'initial' : 'center',
-                        px: open ? 4.5 : 2.5, // Indent for sub-items
-                      }}
-                    >
-                      <ListItemIcon
+                  {isSuperAdmin && (
+                    <ListItem disablePadding sx={{ display: 'block' }}>
+                      <ListItemButton
+                        component={NavLink}
+                        to="/admin/teams"
                         sx={{
-                          minWidth: 0,
-                          mr: open ? 3 : 'auto',
-                          justifyContent: 'center',
+                          minHeight: 48,
+                          justifyContent: open ? 'initial' : 'center',
+                          px: open ? 4.5 : 2.5, // Indent for sub-items
                         }}
                       >
-                        <GroupWorkIcon />
-                      </ListItemIcon>
-                      <ListItemText primary="Teams" sx={{ opacity: open ? 1 : 0 }} />
-                    </ListItemButton>
-                  </ListItem>
+                        <ListItemIcon
+                          sx={{
+                            minWidth: 0,
+                            mr: open ? 3 : 'auto',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <GroupWorkIcon />
+                        </ListItemIcon>
+                        <ListItemText primary="Teams" sx={{ opacity: open ? 1 : 0 }} />
+                      </ListItemButton>
+                    </ListItem>
+                  )}
 
                   <ListItem disablePadding sx={{ display: 'block' }}>
                     <ListItemButton

--- a/app/frontend/src/models/Team.ts
+++ b/app/frontend/src/models/Team.ts
@@ -2,5 +2,6 @@ export interface TeamDto {
   id: string; // GUID is a string in TS/JS
   name: string;
   adminId: string;
+  adminName: string;
   createdAt: string; // Dates are strings over HTTP
 }

--- a/app/frontend/src/pages/AdminUsersPage.tsx
+++ b/app/frontend/src/pages/AdminUsersPage.tsx
@@ -25,9 +25,14 @@ import {
   List,
   ListItem,
   Grid,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
 } from '@mui/material';
 import { Delete as DeleteIcon } from '@mui/icons-material';
 import { useUsers } from '../hooks/useUsers';
+import { useAuth } from '../context/AuthContext';
 import { useSnackbar } from 'notistack';
 import { deleteUser } from '../services/userService';
 import useTeams from '../hooks/useTeams'; // For team selection in invitations
@@ -69,6 +74,7 @@ function a11yProps(index: number) {
 
 const AdminUsersPage: React.FC = () => {
   const [value, setValue] = useState(0);
+  const { user: currentUser } = useAuth();
   const { users, isLoading: isLoadingUsers, isError: isErrorUsers, mutate } = useUsers();
   const { enqueueSnackbar } = useSnackbar();
 
@@ -214,6 +220,7 @@ const AdminUsersPage: React.FC = () => {
                         aria-label="delete user"
                         onClick={() => handleDeleteUserClick(user.id, user.name || user.email)}
                         color="error"
+                        disabled={currentUser?.sub === user.id}
                       >
                         <DeleteIcon />
                       </IconButton>
@@ -237,23 +244,22 @@ const AdminUsersPage: React.FC = () => {
               <Typography variant="h6" component="h2" gutterBottom>
                 Select a Team to Manage Invitations
               </Typography>
-              <select
-                value={selectedTeamId || ''}
-                onChange={(e) => setSelectedTeamId(e.target.value)}
-                style={{
-                  padding: '8px',
-                  borderRadius: '4px',
-                  border: '1px solid #ccc',
-                  marginBottom: '16px',
-                }}
-              >
-                <option value="">Select a team</option>
-                {teams.map((team: TeamWithMembersAndSprints) => (
-                  <option key={team.id} value={team.id}>
-                    {team.name}
-                  </option>
-                ))}
-              </select>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <InputLabel id="team-select-label">Select a team</InputLabel>
+                <Select
+                  labelId="team-select-label"
+                  id="team-select"
+                  value={selectedTeamId || ''}
+                  label="Select a team"
+                  onChange={(e) => setSelectedTeamId(e.target.value)}
+                >
+                  {teams.map((team: TeamWithMembersAndSprints) => (
+                    <MenuItem key={team.id} value={team.id}>
+                      {team.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
             </Box>
 
             {selectedTeamId && (

--- a/app/frontend/src/pages/DashboardPage.tsx
+++ b/app/frontend/src/pages/DashboardPage.tsx
@@ -6,7 +6,8 @@ import type { TeamWithMembersAndSprints } from '../models/Team/TeamWithMembersAn
 import type { Sprint } from '../models/Sprint';
 
 // Material UI Imports
-import { Typography, Box, Card, CardContent, CircularProgress } from '@mui/material';
+import { Typography, Box, Card, CardContent, CircularProgress, Chip } from '@mui/material';
+import { Face as FaceIcon } from '@mui/icons-material';
 
 const DashboardPage: React.FC = () => {
   const { teams, isLoading: isLoadingTeams, isError: isErrorTeams } = useTeams();
@@ -71,9 +72,20 @@ const TeamDashboardSection: React.FC<TeamDashboardSectionProps> = ({ team }) => 
   return (
     <Card sx={{ mb: 4, p: 2, boxShadow: 3 }}>
       <CardContent>
-        <Typography variant="h5" component="h2" gutterBottom>
-          {team.name} - Current Sprint
-        </Typography>
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}
+        >
+          <Typography variant="h5" component="h2" gutterBottom>
+            {team.name} - Current Sprint
+          </Typography>
+          <Chip
+            icon={<FaceIcon />}
+            label={`Owner: ${team.adminName}`}
+            variant="outlined"
+            size="small"
+            color="primary"
+          />
+        </Box>
         {currentSprint ? (
           <Box>
             <Typography variant="subtitle1" color="text.secondary">


### PR DESCRIPTION
- **Security:** Prevent users from deleting their own account via API and disable the delete button in the UI for the current user.
- **Teams:** Add AdminName to TeamDto and populate it in TeamsController to identify team owners.
- **UI:**
  - Display Owner chip on team cards in Dashboard and Admin lists.
  - Replace native team selection dropdown with Material UI Select in Admin Users page for consistency.
- **Navigation:**
  - Unlock Admin sidebar menu for Team Admins (Users & Sprints management).
  - Hide Teams management menu item for non-Super Admins.
- **Access Control:** Update ProtectedRoute in App.tsx to allow Team Admins on specific admin routes.