### PR TITLE
docs: add architecture documentation and English API metadata

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -1,0 +1,147 @@
+# Niko Niko Calendar - Architecture Documentation
+
+This document describes the technical architecture, data models, and workflows of the Niko Niko Calendar application.
+
+## 1. System Overview
+
+The application follows a distributed architecture composed of several decoupled services orchestrated using Docker.
+
+```mermaid
+graph TD
+    User([User's Browser])
+    
+    subgraph "Docker Environment"
+        Frontend[Frontend - React/Vite]
+        API[Main API - .NET 10]
+        Notifications[Notification Service - SignalR]
+        DB[(PostgreSQL/SQLite)]
+    end
+
+    User -->|HTTP/HTTPS| Frontend
+    User -->|REST API| API
+    User -->|WebSocket| Notifications
+    API -->|SQL| DB
+    API -->|HTTP| Notifications
+```
+
+### Components:
+*   **Frontend**: A React 19 application built with TypeScript and Vite. It provides the user interface for tracking morale and managing teams.
+*   **Main API**: A .NET 10 Web API handling business logic, authentication, and data persistence.
+*   **Notification Service**: A dedicated .NET service for real-time notifications using SignalR.
+*   **Database**: Persistent storage using either PostgreSQL (Production) or SQLite (Development/Portable).
+
+---
+
+## 2. Database Schema
+
+The following diagram illustrates the core data models and their relationships.
+
+```mermaid
+erDiagram
+    USER ||--o{ TEAM_USER : participates
+    USER ||--o{ TEAM : administers
+    USER ||--o{ BADGE : earns
+    USER ||--o{ MOOD_ENTRY : records
+    USER ||--o{ TEAM_INVITATION : creates
+
+    TEAM ||--o{ TEAM_USER : contains
+    TEAM ||--o{ SPRINT : has
+    TEAM ||--o{ TEAM_INVITATION : issues
+
+    SPRINT ||--o{ MOOD_ENTRY : includes
+
+    USER {
+        Guid Id
+        string OAuthId
+        string Email
+        string Name
+        string AvatarUrl
+        bool IsSuperAdmin
+        DateTime CreatedAt
+    }
+
+    TEAM {
+        Guid Id
+        string Name
+        Guid AdminId
+        DateTime CreatedAt
+    }
+
+    TEAM_USER {
+        Guid UserId
+        Guid TeamId
+        bool IsAdmin
+        DateTime JoinedAt
+    }
+
+    SPRINT {
+        Guid Id
+        string Name
+        DateTime StartDate
+        DateTime EndDate
+        Guid TeamId
+    }
+
+    MOOD_ENTRY {
+        Guid Id
+        Guid UserId
+        Guid SprintId
+        DateTime Date
+        string Mood
+    }
+
+    TEAM_INVITATION {
+        Guid Id
+        Guid TeamId
+        string Token
+        DateTime ExpirationDate
+        string Status
+        Guid AcceptedByUserId
+    }
+```
+
+---
+
+## 3. Authentication Workflow
+
+Authentication is handled via OAuth 2.0 (GitHub/Google) and secured using JWT (JSON Web Tokens).
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant F as Frontend
+    participant A as Main API
+    participant P as OAuth Provider (GitHub/Google)
+
+    U->>F: Clicks Login
+    F->>A: Redirects to /api/auth/login-github
+    A->>P: Challenge OAuth Request
+    P->>U: Requests Consent
+    U->>P: Grants Permission
+    P->>A: Callback with Code (/signin-github)
+    A->>A: Exchange Code for Profile Info
+    A->>A: Create/Update User & Generate JWT
+    A->>F: Redirect to Callback with JWT
+    F->>F: Store JWT in LocalStorage
+    F->>A: Subsequent Requests (Authorization: Bearer <Token>)
+```
+
+---
+
+## 4. Real-time Notifications
+
+The application uses SignalR for real-time updates (e.g., when a team member submits their mood).
+
+1.  **Subscription**: The Frontend connects to the `NotificationHub` in the `NikoNiko.Notifications` service.
+2.  **Trigger**: When an action occurs in the `Main API` (e.g., `MoodEntry` created), it sends an internal HTTP request to the `Notifications` service.
+3.  **Broadcast**: The `Notifications` service broadcasts the message to the relevant connected clients.
+
+---
+
+## 5. API Standards
+
+The API is built following RESTful principles:
+*   **Documentation**: Automatically generated via OpenAPI/Swagger. Accessible at `/swagger` in development.
+*   **Formats**: JSON for request and response bodies.
+*   **Security**: Most endpoints require a valid JWT passed in the `Authorization` header.
+*   **Versioning**: Current endpoints are under `api/`.

--- a/api/NikoNiko.Api/Controllers/TeamInvitationsController.cs
+++ b/api/NikoNiko.Api/Controllers/TeamInvitationsController.cs
@@ -25,10 +25,10 @@ namespace NikoNiko.Api.Controllers
         }
 
         /// <summary>
-        /// Crée une nouvelle invitation d'équipe. Accessible uniquement par les administrateurs d'équipe.
+        /// Creates a new team invitation. Accessible only by team administrators.
         /// </summary>
-        /// <param name="createDto">Les données nécessaires pour créer une invitation.</param>
-        /// <returns>L'objet TeamInvitationDto de l'invitation créée.</returns>
+        /// <param name="createDto">The data needed to create an invitation.</param>
+        /// <returns>The TeamInvitationDto object of the created invitation.</returns>
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -62,10 +62,10 @@ namespace NikoNiko.Api.Controllers
         }
 
         /// <summary>
-        /// Accepte une invitation d'équipe. Accessible par tout utilisateur authentifié.
+        /// Accepts a team invitation. Accessible by any authenticated user.
         /// </summary>
-        /// <param name="token">Le jeton d'invitation.</param>
-        /// <returns>L'objet TeamInvitationDto de l'invitation acceptée.</returns>
+        /// <param name="token">The invitation token.</param>
+        /// <returns>The TeamInvitationDto object of the accepted invitation.</returns>
         [AllowAnonymous] 
         [HttpPost("{token}/accept")]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -100,10 +100,10 @@ namespace NikoNiko.Api.Controllers
         }
 
         /// <summary>
-        /// Récupère toutes les invitations pour une équipe spécifique. Accessible par les membres de l'équipe ou un super-admin.
+        /// Retrieves all invitations for a specific team. Accessible by team members or a super-admin.
         /// </summary>
-        /// <param name="teamId">L'ID de l'équipe.</param>
-        /// <returns>Une liste d'objets TeamInvitationDto.</returns>
+        /// <param name="teamId">The ID of the team.</param>
+        /// <returns>A list of TeamInvitationDto objects.</returns>
         [HttpGet("/api/teams/{teamId}/invitations")] // This route is absolute and not ideal, but matches existing front-end calls.
         [Authorize(Policy = "IsTeamMember")] // Policy will check if user is member of this team
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -151,9 +151,9 @@ namespace NikoNiko.Api.Controllers
         }
 
         /// <summary>
-        /// Supprime une invitation d'équipe spécifique. Accessible uniquement par les administrateurs d'équipe ou super-admin.
+        /// Deletes a specific team invitation. Accessible only by team administrators or super-admin.
         /// </summary>
-        /// <param name="invitationId">L'ID de l'invitation à supprimer.</param>
+        /// <param name="invitationId">The ID of the invitation to delete.</param>
         [HttpDelete("{invitationId}")]
         [Authorize(Policy = "IsTeamAdmin")] // Policy will check if user is admin of the team for this invitation
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/api/NikoNiko.Api/Controllers/TeamsController.cs
+++ b/api/NikoNiko.Api/Controllers/TeamsController.cs
@@ -11,7 +11,7 @@ using NikoNiko.Core.Models; // Ensure this is explicitly used
 namespace NikoNiko.Api.Controllers;
 
 /// <summary>
-/// Contrôleur pour la gestion des équipes.
+/// Controller for managing teams.
 /// </summary>
 [Authorize]
 [ApiController]
@@ -26,11 +26,11 @@ public class TeamsController : ControllerBase
     }
 
     /// <summary>
-    /// Récupère la liste de toutes les équipes.
-    /// Pour les utilisateurs normaux, ne retourne que les équipes dont ils sont membres ou administrateurs.
-    /// Pour les super-admins, retourne toutes les équipes.
+    /// Retrieves a list of all teams.
+    /// For regular users, returns only teams where they are members or administrators.
+    /// For super-admins, returns all teams.
     /// </summary>
-    /// <returns>Une liste d'objets TeamDto.</returns>
+    /// <returns>A list of TeamWithSprintsDto objects.</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -86,11 +86,11 @@ public class TeamsController : ControllerBase
     }
 
     /// <summary>
-    /// Récupère une équipe spécifique par son ID.
-    /// Un utilisateur doit être membre de l'équipe ou super-admin pour y accéder.
+    /// Retrieves a specific team by its ID.
+    /// A user must be a team member or a super-admin to access it.
     /// </summary>
-    /// <param name="teamId">L'ID de l'équipe.</param>
-    /// <returns>L'objet TeamDto correspondant à l'ID, ou NotFound si l'équipe n'existe pas.</returns>
+    /// <param name="teamId">The ID of the team.</param>
+    /// <returns>The TeamWithSprintsDto object corresponding to the ID, or NotFound if the team does not exist.</returns>
     [HttpGet("{teamId}")]
     [Authorize(Policy = "IsTeamMember")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -164,11 +164,11 @@ public class TeamsController : ControllerBase
     }
 
     /// <summary>
-    /// Crée une nouvelle équipe.
-    /// Accessible uniquement par un Super-admin.
+    /// Creates a new team.
+    /// Accessible only by a Super-admin.
     /// </summary>
-    /// <param name="createTeamDto">Les données nécessaires pour créer une équipe.</param>
-    /// <returns>L'objet TeamDto de l'équipe créée.</returns>
+    /// <param name="createTeamDto">The data needed to create a team.</param>
+    /// <returns>The TeamDto object of the created team.</returns>
     [HttpPost]
     [Authorize(Policy = "SuperAdmin")]
     [ProducesResponseType(StatusCodes.Status201Created)]

--- a/api/NikoNiko.Api/Controllers/UsersController.cs
+++ b/api/NikoNiko.Api/Controllers/UsersController.cs
@@ -100,8 +100,18 @@ public class UsersController : ControllerBase
         return Ok(user);
     }
     
+    /// <summary>
+    /// Deletes a specific user account. Accessible only by super-admins.
+    /// A user cannot delete their own account.
+    /// </summary>
+    /// <param name="id">The ID of the user to delete.</param>
+    /// <returns>NoContent if successful, or an error response.</returns>
     [HttpDelete("{id}")]
     [Authorize(Policy = "SuperAdmin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteUser(Guid id)
     {
         var currentUserIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);

--- a/api/NikoNiko.Api/Program.cs
+++ b/api/NikoNiko.Api/Program.cs
@@ -139,6 +139,14 @@ builder.Services.AddSwaggerGen(options =>
 {
     var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+    
+    // Also include XML comments from Core project if they exist
+    var coreXmlFilename = "NikoNiko.Core.xml";
+    var coreXmlPath = Path.Combine(AppContext.BaseDirectory, coreXmlFilename);
+    if (File.Exists(coreXmlPath))
+    {
+        options.IncludeXmlComments(coreXmlPath);
+    }
 });
 
 builder.Services.AddHealthChecks();

--- a/api/NikoNiko.Core/DTOs/Team/CreateTeamDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/CreateTeamDto.cs
@@ -3,12 +3,12 @@ using System.ComponentModel.DataAnnotations;
 namespace NikoNiko.Core.DTOs.Team;
 
 /// <summary>
-/// Représente les données nécessaires pour créer une nouvelle équipe.
+/// Represents the data needed to create a new team.
 /// </summary>
 public class CreateTeamDto
 {
     /// <summary>
-    /// Le nom de l'équipe.
+    /// The name of the team.
     /// </summary>
     [Required]
     [MaxLength(100)]

--- a/api/NikoNiko.Core/DTOs/Team/Invitation/CreateTeamInvitationDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/Invitation/CreateTeamInvitationDto.cs
@@ -1,8 +1,17 @@
 namespace NikoNiko.Core.DTOs.Team.Invitation
 {
+    /// <summary>
+    /// Represents the data needed to create a new team invitation.
+    /// </summary>
     public class CreateTeamInvitationDto
     {
+        /// <summary>
+        /// The ID of the team for which the invitation is being created.
+        /// </summary>
         public Guid TeamId { get; set; }
-        public int ExpirationInDays { get; set; } = 7; // Default to 7 days
+        /// <summary>
+        /// The number of days before the invitation expires. Defaults to 7 days.
+        /// </summary>
+        public int ExpirationInDays { get; set; } = 7;
     }
 }

--- a/api/NikoNiko.Core/DTOs/Team/Invitation/TeamInvitationDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/Invitation/TeamInvitationDto.cs
@@ -1,17 +1,53 @@
 namespace NikoNiko.Core.DTOs.Team.Invitation
 {
+    /// <summary>
+    /// Represents the data of a team invitation for display.
+    /// </summary>
     public class TeamInvitationDto
     {
+        /// <summary>
+        /// Unique identifier for the invitation.
+        /// </summary>
         public Guid Id { get; set; }
+        /// <summary>
+        /// The ID of the team the invitation is for.
+        /// </summary>
         public Guid TeamId { get; set; }
-        public string? TeamName { get; set; } // Made nullable
+        /// <summary>
+        /// The name of the team the invitation is for.
+        /// </summary>
+        public string? TeamName { get; set; }
+        /// <summary>
+        /// The ID of the user who created the invitation.
+        /// </summary>
         public Guid CreatorUserId { get; set; }
-        public string? CreatorUserName { get; set; } // Made nullable
+        /// <summary>
+        /// The name of the user who created the invitation.
+        /// </summary>
+        public string? CreatorUserName { get; set; }
+        /// <summary>
+        /// Unique token used to identify and accept the invitation.
+        /// </summary>
         public string Token { get; set; } = null!;
+        /// <summary>
+        /// The date and time when the invitation expires.
+        /// </summary>
         public DateTime ExpirationDate { get; set; }
+        /// <summary>
+        /// The current status of the invitation (e.g., Pending, Accepted).
+        /// </summary>
         public string Status { get; set; } = null!;
+        /// <summary>
+        /// The date and time when the invitation was created.
+        /// </summary>
         public DateTime CreatedAt { get; set; }
+        /// <summary>
+        /// The ID of the user who accepted the invitation, if any.
+        /// </summary>
         public Guid? AcceptedByUserId { get; set; }
+        /// <summary>
+        /// The date and time when the invitation was accepted.
+        /// </summary>
         public DateTime? AcceptedAt { get; set; }
     }
 }

--- a/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
@@ -1,28 +1,28 @@
 namespace NikoNiko.Core.DTOs.Team;
 
 /// <summary>
-/// Représente les données d'une équipe pour l'affichage.
+/// Represents the data of a team for display.
 /// </summary>
 public class TeamDto
 {
     /// <summary>
-    /// L'identifiant unique de l'équipe.
+    /// The unique identifier of the team.
     /// </summary>
     public Guid Id { get; set; }
     /// <summary>
-    /// Le nom de l'équipe.
+    /// The name of the team.
     /// </summary>
     public string Name { get; set; } = null!;
     /// <summary>
-    /// L'identifiant de l'administrateur de l'équipe.
+    /// The ID of the team's administrator.
     /// </summary>
     public Guid AdminId { get; set; }
     /// <summary>
-    /// Le nom de l'administrateur de l'équipe.
+    /// The name of the team's administrator.
     /// </summary>
     public string AdminName { get; set; } = null!;
     /// <summary>
-    /// La date de création de l'équipe.
+    /// The date and time when the team was created.
     /// </summary>
     public DateTime CreatedAt { get; set; }
 }

--- a/api/NikoNiko.Core/Models/Badge.cs
+++ b/api/NikoNiko.Core/Models/Badge.cs
@@ -2,20 +2,42 @@ using System.ComponentModel.DataAnnotations;
 
 namespace NikoNiko.Core.Models;
 
+/// <summary>
+/// Represents a gamification badge earned by a user.
+/// </summary>
 public class Badge
 {
+    /// <summary>
+    /// Unique identifier for the badge instance.
+    /// </summary>
     public Guid Id { get; set; }
 
+    /// <summary>
+    /// The ID of the user who earned this badge.
+    /// </summary>
     [Required]
     public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Navigation property for the user who earned this badge.
+    /// </summary>
     public User User { get; set; } = null!;
 
+    /// <summary>
+    /// The name of the badge.
+    /// </summary>
     [Required]
     [MaxLength(100)]
     public string Name { get; set; } = null!;
 
+    /// <summary>
+    /// A description of why the badge was awarded.
+    /// </summary>
     [Required]
     public string Description { get; set; } = null!;
 
+    /// <summary>
+    /// The date and time when the badge was earned.
+    /// </summary>
     public DateTime EarnedAt { get; set; } = DateTime.UtcNow;
 }

--- a/api/NikoNiko.Core/Models/MoodEntry.cs
+++ b/api/NikoNiko.Core/Models/MoodEntry.cs
@@ -2,20 +2,46 @@ using System.ComponentModel.DataAnnotations;
 
 namespace NikoNiko.Core.Models;
 
+/// <summary>
+/// Records a user's mood for a specific date within a sprint.
+/// </summary>
 public class MoodEntry
 {
+    /// <summary>
+    /// Unique identifier for the mood entry.
+    /// </summary>
     public Guid Id { get; set; }
 
+    /// <summary>
+    /// The ID of the user who recorded this mood.
+    /// </summary>
     [Required]
     public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Navigation property for the user who recorded this mood.
+    /// </summary>
     public User User { get; set; } = null!;
 
+    /// <summary>
+    /// The ID of the sprint this mood entry belongs to.
+    /// </summary>
     [Required]
     public Guid SprintId { get; set; }
+
+    /// <summary>
+    /// Navigation property for the sprint associated with this mood entry.
+    /// </summary>
     public Sprint Sprint { get; set; } = null!;
 
+    /// <summary>
+    /// The date for which the mood is recorded.
+    /// </summary>
     public DateTime Date { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// The type of mood recorded (e.g., Happy, Neutral, Sad).
+    /// </summary>
     [Required]
     public MoodType Mood { get; set; }
 }

--- a/api/NikoNiko.Core/Models/Sprint.cs
+++ b/api/NikoNiko.Core/Models/Sprint.cs
@@ -2,23 +2,48 @@ using System.ComponentModel.DataAnnotations;
 
 namespace NikoNiko.Core.Models;
 
+/// <summary>
+/// Represents a time-boxed work period (Sprint) for a team.
+/// </summary>
 public class Sprint
 {
+    /// <summary>
+    /// Unique identifier for the sprint.
+    /// </summary>
     public Guid Id { get; set; }
 
+    /// <summary>
+    /// The name of the sprint (e.g., "Sprint 1", "January Iteration").
+    /// </summary>
     [Required]
     [MaxLength(100)]
     public string Name { get; set; } = null!;
 
+    /// <summary>
+    /// The starting date and time of the sprint.
+    /// </summary>
     [Required]
     public DateTime StartDate { get; set; }
 
+    /// <summary>
+    /// The ending date and time of the sprint.
+    /// </summary>
     [Required]
     public DateTime EndDate { get; set; }
 
+    /// <summary>
+    /// The ID of the team this sprint belongs to.
+    /// </summary>
     [Required]
     public Guid TeamId { get; set; }
+
+    /// <summary>
+    /// Navigation property for the team associated with this sprint.
+    /// </summary>
     public Team Team { get; set; } = null!;
 
+    /// <summary>
+    /// Navigation property for the mood entries recorded during this sprint.
+    /// </summary>
     public List<MoodEntry> MoodEntries { get; set; } = new();
 }

--- a/api/NikoNiko.Core/Models/Team.cs
+++ b/api/NikoNiko.Core/Models/Team.cs
@@ -3,23 +3,47 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NikoNiko.Core.Models;
 
+/// <summary>
+/// Represents an Agile team.
+/// </summary>
 public class Team
 {
+    /// <summary>
+    /// Unique identifier for the team.
+    /// </summary>
     public Guid Id { get; set; }
 
+    /// <summary>
+    /// The name of the team.
+    /// </summary>
     [Required]
     [MaxLength(100)]
     public string Name { get; set; } = null!;
 
+    /// <summary>
+    /// The ID of the user who manages the team.
+    /// </summary>
     [Required]
     public Guid AdminId { get; set; }
 
+    /// <summary>
+    /// Navigation property for the team's administrator.
+    /// </summary>
     [ForeignKey("AdminId")]
     public User Admin { get; set; } = null!;
 
+    /// <summary>
+    /// The date and time when the team was created.
+    /// </summary>
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Navigation property for the members of the team.
+    /// </summary>
     public List<TeamUser> TeamUsers { get; set; } = new();
 
+    /// <summary>
+    /// Navigation property for the sprints associated with this team.
+    /// </summary>
     public List<Sprint> Sprints { get; set; } = new();
 }

--- a/api/NikoNiko.Core/Models/TeamInvitation.cs
+++ b/api/NikoNiko.Core/Models/TeamInvitation.cs
@@ -2,20 +2,74 @@ using System;
 
 namespace NikoNiko.Core.Models
 {
+    /// <summary>
+    /// Represents an invitation to join a team.
+    /// </summary>
     public class TeamInvitation
     {
+        /// <summary>
+        /// Unique identifier for the invitation.
+        /// </summary>
         public Guid Id { get; set; }
+
+        /// <summary>
+        /// The ID of the team the invitation is for.
+        /// </summary>
         public Guid TeamId { get; set; }
-        public Team? Team { get; set; } // Made nullable
+
+        /// <summary>
+        /// Navigation property for the team associated with the invitation.
+        /// </summary>
+        public Team? Team { get; set; }
+
+        /// <summary>
+        /// The ID of the user who created the invitation.
+        /// </summary>
         public Guid CreatorUserId { get; set; }
-        public User? CreatorUser { get; set; } // Made nullable
-        public string Token { get; set; } = null!; // Keep as non-nullable, must be set
+
+        /// <summary>
+        /// Navigation property for the user who created the invitation.
+        /// </summary>
+        public User? CreatorUser { get; set; }
+
+        /// <summary>
+        /// Unique token used to identify and accept the invitation.
+        /// </summary>
+        public string Token { get; set; } = null!;
+
+        /// <summary>
+        /// The date and time when the invitation expires.
+        /// </summary>
         public DateTime ExpirationDate { get; set; }
-        public string Status { get; set; } = "Pending"; // Default status
+
+        /// <summary>
+        /// The current status of the invitation (e.g., Pending, Accepted).
+        /// </summary>
+        public string Status { get; set; } = "Pending";
+
+        /// <summary>
+        /// The date and time when the invitation was created.
+        /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// The ID of the user who accepted the invitation, if any.
+        /// </summary>
         public Guid? AcceptedByUserId { get; set; }
-        public User? AcceptedByUser { get; set; } // Made nullable
+
+        /// <summary>
+        /// Navigation property for the user who accepted the invitation.
+        /// </summary>
+        public User? AcceptedByUser { get; set; }
+
+        /// <summary>
+        /// The date and time when the invitation was accepted.
+        /// </summary>
         public DateTime? AcceptedAt { get; set; }
-        public bool IsDeleted { get; set; } = false; // Pour le soft delete
+
+        /// <summary>
+        /// Indicates if the invitation has been soft-deleted.
+        /// </summary>
+        public bool IsDeleted { get; set; } = false;
     }
 }

--- a/api/NikoNiko.Core/Models/TeamUser.cs
+++ b/api/NikoNiko.Core/Models/TeamUser.cs
@@ -2,17 +2,40 @@ using System.ComponentModel.DataAnnotations;
 
 namespace NikoNiko.Core.Models;
 
+/// <summary>
+/// Represents the join table for the many-to-many relationship between Users and Teams.
+/// </summary>
 public class TeamUser
 {
+    /// <summary>
+    /// The ID of the user.
+    /// </summary>
     [Required]
     public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Navigation property for the user.
+    /// </summary>
     public User User { get; set; } = null!;
 
+    /// <summary>
+    /// The ID of the team.
+    /// </summary>
     [Required]
     public Guid TeamId { get; set; }
+
+    /// <summary>
+    /// Navigation property for the team.
+    /// </summary>
     public Team Team { get; set; } = null!;
 
+    /// <summary>
+    /// Indicates whether the user has administrative rights within this specific team.
+    /// </summary>
     public bool IsAdmin { get; set; } = false;
 
+    /// <summary>
+    /// The date and time when the user joined the team.
+    /// </summary>
     public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
 }

--- a/api/NikoNiko.Core/Models/User.cs
+++ b/api/NikoNiko.Core/Models/User.cs
@@ -2,28 +2,58 @@ using System.ComponentModel.DataAnnotations;
 
 namespace NikoNiko.Core.Models;
 
+/// <summary>
+/// Represents a user within the NikoNiko application.
+/// </summary>
 public class User
 {
+    /// <summary>
+    /// Unique identifier for the user.
+    /// </summary>
     public Guid Id { get; set; }
 
+    /// <summary>
+    /// The unique ID provided by the OAuth provider (e.g., GitHub, Google).
+    /// </summary>
     [Required]
     public string OAuthId { get; set; } = null!;
 
+    /// <summary>
+    /// The user's email address.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; } = null!;
 
+    /// <summary>
+    /// The user's full name or display name.
+    /// </summary>
     [Required]
     [MaxLength(100)]
     public string Name { get; set; } = null!;
 
+    /// <summary>
+    /// URL to the user's avatar image.
+    /// </summary>
     public string? AvatarUrl { get; set; }
 
+    /// <summary>
+    /// Indicates whether the user has system-wide administrative privileges.
+    /// </summary>
     public bool IsSuperAdmin { get; set; } = false;
 
+    /// <summary>
+    /// The date and time when the user account was created.
+    /// </summary>
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Navigation property for the relationship between users and teams.
+    /// </summary>
     public List<TeamUser> TeamUsers { get; set; } = new();
 
+    /// <summary>
+    /// Navigation property for the badges earned by the user.
+    /// </summary>
     public List<Badge> Badges { get; set; } = new();
 }

--- a/api/NikoNiko.Core/NikoNiko.Core.csproj
+++ b/api/NikoNiko.Core/NikoNiko.Core.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/api/NikoNiko.Data/NikoNiko.Data.csproj
+++ b/api/NikoNiko.Data/NikoNiko.Data.csproj
@@ -18,6 +18,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/api/NikoNiko.Services/NikoNiko.Services.csproj
+++ b/api/NikoNiko.Services/NikoNiko.Services.csproj
@@ -16,6 +16,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/plans/architecture_documentation.md
+++ b/plans/architecture_documentation.md
@@ -1,0 +1,66 @@
+# Implementation Plan - Architecture Documentation
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Create a comprehensive English documentation of the system's architecture in `Architecture.md` at the root and ensure all API documentation (Swagger/XML) is professional and in English.
+*   **Affected Files:**
+    *   `Architecture.md` (New)
+    *   `api/NikoNiko.Api/NikoNiko.Api.csproj`
+    *   `api/NikoNiko.Core/NikoNiko.Core.csproj`
+    *   `api/NikoNiko.Api/Controllers/*.cs`
+    *   `api/NikoNiko.Core/Models/*.cs`
+    *   `api/NikoNiko.Core/DTOs/**/*.cs`
+*   **Key Dependencies:** Mermaid.js (for diagrams), Swashbuckle.AspNetCore (for Swagger).
+*   **Risks/Unknowns:** Ensuring all Mermaid diagrams accurately reflect the EF Core configuration and SignalR communication flow.
+
+## 2. 📋 Checklist
+- [ ] Step 1: Enable XML Documentation generation in .NET projects.
+- [ ] Step 2: Translate and enrich XML documentation for Models and DTOs.
+- [ ] Step 3: Translate and enrich XML documentation for Controllers.
+- [ ] Step 4: Create the `Architecture.md` file with Mermaid diagrams.
+- [ ] Verification: Validate Swagger UI and Markdown rendering.
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### Step 1: Enable XML Documentation
+*   **Goal:** Ensure the compiler generates XML files for Swagger to consume.
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/NikoNiko.Api.csproj` and `api/NikoNiko.Core/NikoNiko.Core.csproj` to add `<GenerateDocumentationFile>true</GenerateDocumentationFile>`.
+    *   Suppress warning 1591 (missing XML comments) if it becomes too noisy during transition.
+*   **Verification:** Check if `.xml` files are generated in `bin/` after build.
+
+### Step 2: Document Models and DTOs
+*   **Goal:** Provide clear English descriptions for data structures.
+*   **Action:**
+    *   Add `<summary>` tags to all classes and properties in `api/NikoNiko.Core/Models` and `api/NikoNiko.Core/DTOs`.
+    *   Translate any existing French comments found in these files.
+*   **Verification:** Inspect DTOs in Swagger UI "Schemas" section.
+
+### Step 3: Document Controllers
+*   **Goal:** Document API endpoints, parameters, and response types.
+*   **Action:**
+    *   Add XML comments to all methods in `api/NikoNiko.Api/Controllers`.
+    *   Include `<response code="...">` tags for common HTTP status codes.
+*   **Verification:** Inspect endpoint descriptions in Swagger UI.
+
+### Step 4: Create Architecture.md
+*   **Goal:** High-level architectural overview in English.
+*   **Action:**
+    *   Create `Architecture.md` at the project root.
+    *   Add **Service Architecture** section with a Mermaid `graph TD` showing Frontend, API, Notifications (SignalR), and DB.
+    *   Add **Database Schema** section with a Mermaid `erDiagram` showing relationships (Users, Teams, Sprints, MoodEntries).
+    *   Add **Authentication Workflow** section with a Mermaid `sequenceDiagram` showing OAuth2/JWT flow.
+    *   Add **Real-time Notifications** section explaining the SignalR hub.
+*   **Verification:** View the file in a Markdown previewer with Mermaid support.
+
+## 4. 🧪 Testing Strategy
+*   **Unit Tests:** N/A (Documentation focus).
+*   **Integration Tests:** N/A.
+*   **Manual Verification:**
+    *   Run the API and navigate to `/swagger` to verify all descriptions are in English and accurate.
+    *   Verify `Architecture.md` rendering on GitHub/VS Code.
+
+## 5. ✅ Success Criteria
+*   `Architecture.md` exists at the root and contains valid Mermaid diagrams in English.
+*   Swagger UI displays English descriptions for all endpoints and schemas.
+*   No French comments remain in the documented files.
+*   The project builds without errors related to documentation generation.


### PR DESCRIPTION
- Create Architecture.md at root with Mermaid diagrams (System, ERD, Auth flow)
- Enable XML documentation generation across all .NET projects
- Translate and enrich all Models, DTOs, and Controllers comments in English
- Configure Swagger to aggregate documentation from multiple projects

closes #15 