### PR TITLE
feat(frontend): overhaul dashboard with mood widgets and team trends

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.3",
         "react-router-dom": "^7.12.0",
+        "recharts": "^3.6.0",
         "swr": "^2.3.7"
       },
       "devDependencies": {
@@ -1526,6 +1527,42 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -1883,6 +1920,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1927,6 +1976,69 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1993,6 +2105,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.53.0",
@@ -2655,6 +2773,127 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -2678,6 +2917,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2805,6 +3050,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
+      "integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -3089,6 +3344,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "2.0.2",
@@ -3517,6 +3778,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3541,6 +3812,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -4241,7 +4521,32 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
       "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4305,6 +4610,52 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
+      "integrity": "sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/require-directory": {
@@ -4594,6 +4945,12 @@
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4792,6 +5149,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -24,7 +24,6 @@
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.3",
         "react-router-dom": "^7.12.0",
-        "recharts": "^3.6.0",
         "swr": "^2.3.7"
       },
       "devDependencies": {
@@ -1527,42 +1526,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
-      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -1920,18 +1883,6 @@
         "win32"
       ]
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
-      "license": "MIT"
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1976,69 +1927,6 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2105,12 +1993,6 @@
       "peerDependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.53.0",
@@ -2773,127 +2655,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -2917,12 +2678,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3050,16 +2805,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
-      "integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -3344,12 +3089,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "2.0.2",
@@ -3778,16 +3517,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3812,15 +3541,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -4524,30 +4244,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -4610,52 +4306,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/recharts": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
-      "integrity": "sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==",
-      "license": "MIT",
-      "workspaces": [
-        "www"
-      ],
-      "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^5.0.0"
       }
     },
     "node_modules/require-directory": {
@@ -4945,12 +4595,6 @@
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5149,28 +4793,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -28,7 +28,6 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.3",
     "react-router-dom": "^7.12.0",
-    "recharts": "^3.6.0",
     "swr": "^2.3.7"
   },
   "devDependencies": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.3",
     "react-router-dom": "^7.12.0",
+    "recharts": "^3.6.0",
     "swr": "^2.3.7"
   },
   "devDependencies": {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -22,10 +22,12 @@ import AdminSprintsPage from '@/pages/AdminSprintsPage';
 import AdminTeamsPage from '@/pages/AdminTeamsPage';
 import AdminUsersPage from '@/pages/AdminUsersPage';
 import AuthCallbackPage from '@/pages/AuthCallbackPage';
+// New placeholder pages
+import CurrentSprintsPage from '@/pages/CurrentSprintsPage';
 import DashboardPage from '@/pages/DashboardPage';
 import LoginPage from '@/pages/LoginPage';
-// New placeholder pages
 import PastSprintsPage from '@/pages/PastSprintsPage';
+import SprintDetailsPage from '@/pages/SprintDetailsPage';
 
 import './App.css';
 import 'dayjs/locale/fr';
@@ -80,6 +82,22 @@ function App() {
                 element={
                   <ProtectedRoute>
                     <DashboardPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/teams/:teamId/sprints/:sprintId"
+                element={
+                  <ProtectedRoute>
+                    <SprintDetailsPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/current-sprints"
+                element={
+                  <ProtectedRoute>
+                    <CurrentSprintsPage />
                   </ProtectedRoute>
                 }
               />

--- a/app/frontend/src/components/dashboard/DailyMoodWidget.tsx
+++ b/app/frontend/src/components/dashboard/DailyMoodWidget.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
+import SentimentNeutralIcon from '@mui/icons-material/SentimentNeutral';
+import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt';
+import {
+  alpha,
+  Box,
+  Card,
+  CardContent,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import dayjs, { Dayjs } from 'dayjs';
+import { useSnackbar } from 'notistack';
+
+import { useAuth } from '@/context/AuthContext';
+import { useMoodMutation } from '@/hooks/useMoodMutation';
+import { useMoods } from '@/hooks/useMoods';
+import type { MoodType } from '@/models/MoodType';
+import { MoodValues } from '@/models/MoodType';
+
+interface DailyMoodWidgetProps {
+  sprintId: string;
+  sprintStartDate: string;
+  sprintEndDate: string;
+}
+
+const DailyMoodWidget: React.FC<DailyMoodWidgetProps> = ({
+  sprintId,
+  sprintStartDate,
+  sprintEndDate,
+}) => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const { enqueueSnackbar } = useSnackbar();
+  const theme = useTheme();
+  
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs());
+
+  // Data fetching
+  const { moods, isLoading } = useMoods(sprintId);
+  // Mutation logic
+  const { saveMood, isUpdating } = useMoodMutation(sprintId);
+
+  const serverMood = moods?.find(
+    (m) => m.userId === user?.sub && dayjs(m.date).startOf('day').isSame(selectedDate.startOf('day'))
+  );
+
+  const currentMoodValue = serverMood?.mood;
+
+  const handleMoodSelect = async (moodType: MoodType) => {
+    if (!user || isUpdating) return;
+
+    try {
+      await saveMood(selectedDate, moodType, user.sub);
+      enqueueSnackbar(t('common.success'), { variant: 'success' });
+    } catch {
+      enqueueSnackbar(t('common.error'), { variant: 'error' });
+    }
+  };
+
+  const moodButtons = [
+    {
+      type: MoodValues.Happy,
+      icon: <SentimentSatisfiedAltIcon sx={{ fontSize: 80 }} />,
+      color: theme.palette.success.main,
+      label: t('mood.happy', 'Happy'),
+    },
+    {
+      type: MoodValues.Neutral,
+      icon: <SentimentNeutralIcon sx={{ fontSize: 80 }} />,
+      color: theme.palette.warning.main,
+      label: t('mood.neutral', 'Neutral'),
+    },
+    {
+      type: MoodValues.Sad,
+      icon: <SentimentDissatisfiedIcon sx={{ fontSize: 80 }} />,
+      color: theme.palette.error.main,
+      label: t('mood.sad', 'Sad'),
+    },
+  ];
+
+  return (
+    <Card sx={{ height: '100%', boxShadow: 3, borderRadius: 2 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom align="center">
+          {t('dashboard.howAreYouToday', 'Comment allez-vous ?')}
+        </Typography>
+
+        <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
+          <DatePicker
+            label={t('dashboard.selectDate', 'Sélectionner une date')}
+            value={selectedDate}
+            onChange={(newValue) => newValue && setSelectedDate(newValue)}
+            minDate={dayjs(sprintStartDate)}
+            maxDate={dayjs(sprintEndDate).isBefore(dayjs()) ? dayjs(sprintEndDate) : dayjs()}
+            slotProps={{ textField: { size: 'small', fullWidth: true } }}
+          />
+        </Box>
+
+        <Stack
+          direction="row"
+          spacing={3}
+          justifyContent="center"
+          alignItems="center"
+          sx={{ mt: 4, mb: 2 }}
+        >
+          {isLoading ? (
+            <CircularProgress size={40} />
+          ) : (
+            moodButtons.map((button) => {
+              const isSelected = currentMoodValue === button.type;
+              return (
+                <Tooltip key={button.type} title={button.label}>
+                  <IconButton
+                    onClick={() => handleMoodSelect(button.type)}
+                    disabled={isUpdating}
+                    sx={{
+                      color: isSelected ? '#fff' : theme.palette.text.disabled,
+                      backgroundColor: isSelected ? button.color : 'transparent',
+                      border: `2px solid ${isSelected ? button.color : 'transparent'}`,
+                      transition: 'all 0.2s',
+                      '&:hover': {
+                        backgroundColor: isSelected ? button.color : alpha(button.color, 0.2),
+                        color: isSelected ? '#fff' : button.color,
+                        transform: 'scale(1.1)',
+                      },
+                      p: 2,
+                      width: 110,
+                      height: 110,
+                      '& svg': {
+                        fontSize: 80,
+                      }
+                    }}
+                  >
+                    {button.icon}
+                  </IconButton>
+                </Tooltip>
+              );
+            })
+          )}
+        </Stack>
+
+        {currentMoodValue !== undefined && (
+          <Typography variant="body2" color="text.secondary" align="center" sx={{ mt: 1 }}>
+            {t('dashboard.moodRecorded', 'Humeur enregistrée pour ce jour')}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DailyMoodWidget;

--- a/app/frontend/src/components/dashboard/TeamMoodTrendWidget.tsx
+++ b/app/frontend/src/components/dashboard/TeamMoodTrendWidget.tsx
@@ -1,34 +1,34 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
   Card,
   CardContent,
   CircularProgress,
+  Paper,
   Typography,
   useTheme,
+  Popper,
+  Fade,
 } from '@mui/material';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
-
-dayjs.extend(isSameOrBefore);
 
 import { useMoods } from '@/hooks/useMoods';
 import { MoodValues } from '@/models/MoodType';
+
+dayjs.extend(isSameOrBefore);
 
 interface TeamMoodTrendWidgetProps {
   sprintId: string;
   sprintStartDate: string;
   sprintEndDate: string;
+}
+
+interface ChartDataPoint {
+  date: string;
+  displayDate: string;
+  average: number | null;
 }
 
 const TeamMoodTrendWidget: React.FC<TeamMoodTrendWidgetProps> = ({
@@ -39,13 +39,17 @@ const TeamMoodTrendWidget: React.FC<TeamMoodTrendWidgetProps> = ({
   const { t } = useTranslation();
   const theme = useTheme();
   const { moods, isLoading } = useMoods(sprintId);
+  
+  const [tooltipState, setTooltipState] = useState<{
+    anchorEl: HTMLElement | null; // Changed to HTMLElement for HTML overlays
+    data: ChartDataPoint | null;
+  }>({ anchorEl: null, data: null });
 
-  const chartData = useMemo(() => {
+  const chartData: ChartDataPoint[] = useMemo(() => {
     if (!moods) return [];
 
     const moodsByDate: Record<string, { totalScore: number; count: number }> = {};
-    
-    // Initialize dates in sprint up to today
+
     const start = dayjs(sprintStartDate);
     const end = dayjs(sprintEndDate);
     const today = dayjs().startOf('day');
@@ -58,12 +62,11 @@ const TeamMoodTrendWidget: React.FC<TeamMoodTrendWidgetProps> = ({
     moods.forEach((m) => {
       const dateStr = dayjs(m.date).format('YYYY-MM-DD');
       if (moodsByDate[dateStr]) {
-        // Map: Happy(0) -> 3, Neutral(1) -> 2, Sad(2) -> 1
         let score = 0;
         if (m.mood === MoodValues.Happy) score = 3;
         else if (m.mood === MoodValues.Neutral) score = 2;
         else if (m.mood === MoodValues.Sad) score = 1;
-        
+
         moodsByDate[dateStr].totalScore += score;
         moodsByDate[dateStr].count += 1;
       }
@@ -78,9 +81,68 @@ const TeamMoodTrendWidget: React.FC<TeamMoodTrendWidgetProps> = ({
       .sort((a, b) => a.date.localeCompare(b.date));
   }, [moods, sprintStartDate, sprintEndDate]);
 
+  // Chart Dimensions
+  const VIEWBOX_WIDTH = 100;
+  const VIEWBOX_HEIGHT = 40;
+  const PADDING_TOP = 5;
+  const PADDING_BOTTOM = 5;
+  const CHART_HEIGHT = VIEWBOX_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+
+  const getX = (index: number) => {
+    if (chartData.length <= 1) return VIEWBOX_WIDTH / 2;
+    return (index / (chartData.length - 1)) * VIEWBOX_WIDTH;
+  };
+
+  const getY = (value: number | null) => {
+    if (value === null) return null;
+    const normalized = (value - 1) / (3 - 1); 
+    return PADDING_TOP + CHART_HEIGHT - normalized * CHART_HEIGHT;
+  };
+
+  const points = chartData.map((d, i) => {
+    const y = getY(d.average);
+    return { x: getX(i), y, data: d };
+  });
+
+  const validPoints = points.filter((p) => p.y !== null) as {
+    x: number;
+    y: number;
+    data: ChartDataPoint;
+  }[];
+
+  const getCurvePath = (dataPoints: { x: number; y: number }[]) => {
+    if (dataPoints.length === 0) return '';
+    if (dataPoints.length === 1) return `M ${dataPoints[0].x} ${dataPoints[0].y}`;
+
+    let path = `M ${dataPoints[0].x} ${dataPoints[0].y}`;
+
+    for (let i = 0; i < dataPoints.length - 1; i++) {
+      const p0 = dataPoints[i];
+      const p1 = dataPoints[i + 1];
+      const cp1x = p0.x + (p1.x - p0.x) / 2;
+      const cp1y = p0.y;
+      const cp2x = p0.x + (p1.x - p0.x) / 2;
+      const cp2y = p1.y;
+
+      path += ` C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${p1.x} ${p1.y}`;
+    }
+    return path;
+  };
+
+  const linePath = useMemo(() => getCurvePath(validPoints), [validPoints]);
+
+  const areaPath = useMemo(() => {
+    if (validPoints.length === 0) return '';
+    const first = validPoints[0];
+    const last = validPoints[validPoints.length - 1];
+    return `${linePath} L ${last.x} ${VIEWBOX_HEIGHT} L ${first.x} ${VIEWBOX_HEIGHT} Z`;
+  }, [linePath, validPoints]);
+
   if (isLoading) {
     return (
-      <Card sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <Card
+        sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+      >
         <CircularProgress />
       </Card>
     );
@@ -88,60 +150,166 @@ const TeamMoodTrendWidget: React.FC<TeamMoodTrendWidgetProps> = ({
 
   return (
     <Card sx={{ height: '100%', boxShadow: 3, borderRadius: 2 }}>
-      <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-        <Typography variant="h6" gutterBottom align="center">
-          {t('dashboard.teamTrend', 'Tendance de l\'équipe')}
+      <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', pb: '16px !important' }}>
+        <Typography variant="h6" gutterBottom align="center" sx={{ fontSize: '1rem' }}>
+          {t('dashboard.teamTrend', "Tendance de l'équipe")}
         </Typography>
-        
-        <Box sx={{ flexGrow: 1, minHeight: 200, mt: 2 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={chartData}>
-              <defs>
-                <linearGradient id="colorAverage" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor={theme.palette.primary.main} stopOpacity={0.8} />
-                  <stop offset="95%" stopColor={theme.palette.primary.main} stopOpacity={0} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis 
-                dataKey="displayDate" 
-                tick={{ fontSize: 12 }}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis 
-                domain={[1, 3]} 
-                ticks={[1, 2, 3]}
-                tickFormatter={(value) => {
-                  if (value === 3) return '😊';
-                  if (value === 2) return '😐';
-                  if (value === 1) return '☹️';
-                  return '';
-                }}
-                tick={{ fontSize: 16 }}
-                axisLine={false}
-                tickLine={false}
-              />
-              <Tooltip 
-                formatter={(value: number | undefined) => [value ?? 0, t('dashboard.averageMood', 'Humeur moyenne')]}
-                labelFormatter={(label) => `${t('common.date', 'Date')}: ${label}`}
-                contentStyle={{ 
-                  backgroundColor: theme.palette.background.paper, 
-                  color: theme.palette.text.primary,
-                  border: `1px solid ${theme.palette.divider}`,
-                  borderRadius: '4px'
-                }}
-              />
-              <Area
-                type="monotone"
-                dataKey="average"
-                stroke={theme.palette.primary.main}
-                fillOpacity={1}
-                fill="url(#colorAverage)"
-                connectNulls
-              />
-            </AreaChart>
-          </ResponsiveContainer>
+
+        {/* Container with padding left for labels (ml: 5 = 40px) to avoid overlap with large dots */}
+        <Box sx={{ flexGrow: 1, height: 100, mt: 1, position: 'relative', ml: 5 }}>
+          {chartData.length > 0 ? (
+            <>
+              {/* Background SVG for Lines and Area (Stretched) */}
+              <svg
+                viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+                style={{ width: '100%', height: '100%', overflow: 'visible', display: 'block' }}
+                preserveAspectRatio="none"
+              >
+                <defs>
+                  <linearGradient id="gradientMood" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={theme.palette.primary.main} stopOpacity={0.6} />
+                    <stop offset="100%" stopColor={theme.palette.primary.main} stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+
+                {/* Grid Lines */}
+                {[1, 2, 3].map((val) => {
+                  const y = getY(val);
+                  return (
+                    y !== null && (
+                      <line
+                        key={val}
+                        x1="0"
+                        y1={y}
+                        x2={VIEWBOX_WIDTH}
+                        y2={y}
+                        stroke={theme.palette.divider}
+                        strokeWidth="0.1"
+                        strokeDasharray="1 1"
+                      />
+                    )
+                  );
+                })}
+
+                <path d={areaPath} fill="url(#gradientMood)" />
+
+                <path
+                  d={linePath}
+                  fill="none"
+                  stroke={theme.palette.primary.main}
+                  strokeWidth="0.6"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+
+              {/* HTML Overlay for Labels (Smileys) */}
+              {[3, 2, 1].map((val) => {
+                  const y = getY(val);
+                  const topPercent = y !== null ? (y / VIEWBOX_HEIGHT) * 100 : 0;
+                  const icon = val === 3 ? '😊' : val === 2 ? '😐' : '☹️';
+                  
+                  return (
+                    <Typography
+                      key={val}
+                      variant="caption"
+                      sx={{
+                        position: 'absolute',
+                        left: -32, // Further left (-32px)
+                        top: `${topPercent}%`,
+                        transform: 'translateY(-50%)',
+                        fontSize: '1.2rem', // Slightly larger font for better visibility
+                        lineHeight: 1,
+                        zIndex: 1, // Below dots (dots are z-index 2)
+                      }}
+                    >
+                      {icon}
+                    </Typography>
+                  );
+              })}
+
+              {/* HTML Overlay for Points (perfectly round dots) */}
+              {validPoints.map((p, i) => {
+                  const leftPercent = (p.x / VIEWBOX_WIDTH) * 100;
+                  const topPercent = (p.y / VIEWBOX_HEIGHT) * 100;
+
+                  return (
+                    <Box
+                      key={`dot-${i}`}
+                      sx={{
+                        position: 'absolute',
+                        left: `${leftPercent}%`,
+                        top: `${topPercent}%`,
+                        width: 16, // Back to 2x (16px)
+                        height: 16,
+                        borderRadius: '50%',
+                        backgroundColor: theme.palette.background.paper,
+                        border: `2px solid ${theme.palette.primary.main}`,
+                        transform: 'translate(-50%, -50%)',
+                        cursor: 'pointer',
+                        zIndex: 2, // Above labels
+                        transition: 'transform 0.2s, box-shadow 0.2s',
+                        '&:hover': {
+                           transform: 'translate(-50%, -50%) scale(1.25)',
+                           boxShadow: theme.shadows[3],
+                           zIndex: 3, // Highest when hovered
+                        }
+                      }}
+                      onMouseEnter={(e) => setTooltipState({ anchorEl: e.currentTarget, data: p.data })}
+                      onMouseLeave={() => setTooltipState({ anchorEl: null, data: null })}
+                    />
+                  );
+              })}
+
+              {/* Popper Tooltip */}
+              <Popper 
+                open={Boolean(tooltipState.anchorEl)} 
+                anchorEl={tooltipState.anchorEl} 
+                placement="top" 
+                transition
+                modifiers={[
+                  {
+                    name: 'offset',
+                    options: {
+                      offset: [0, 8],
+                    },
+                  },
+                ]}
+                style={{ zIndex: 1500 }}
+              >
+                {({ TransitionProps }) => (
+                  <Fade {...TransitionProps} timeout={200}>
+                    <Paper
+                      sx={{
+                        p: 1,
+                        border: `1px solid ${theme.palette.divider}`,
+                        backgroundColor: theme.palette.background.paper,
+                        boxShadow: theme.shadows[3],
+                      }}
+                    >
+                       <Typography variant="caption" display="block" color="text.secondary">
+                        {t('common.date')}: {tooltipState.data?.displayDate}
+                      </Typography>
+                      <Typography variant="body2" fontWeight="bold">
+                        {t('dashboard.averageMood')}: {tooltipState.data?.average}
+                      </Typography>
+                    </Paper>
+                  </Fade>
+                )}
+              </Popper>
+            </>
+          ) : (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '100%',
+              }}
+            >
+              <Typography color="text.secondary">{t('common.noData')}</Typography>
+            </Box>
+          )}
         </Box>
       </CardContent>
     </Card>

--- a/app/frontend/src/components/dashboard/TeamMoodTrendWidget.tsx
+++ b/app/frontend/src/components/dashboard/TeamMoodTrendWidget.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Box,
+  Card,
+  CardContent,
+  CircularProgress,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+dayjs.extend(isSameOrBefore);
+
+import { useMoods } from '@/hooks/useMoods';
+import { MoodValues } from '@/models/MoodType';
+
+interface TeamMoodTrendWidgetProps {
+  sprintId: string;
+  sprintStartDate: string;
+  sprintEndDate: string;
+}
+
+const TeamMoodTrendWidget: React.FC<TeamMoodTrendWidgetProps> = ({
+  sprintId,
+  sprintStartDate,
+  sprintEndDate,
+}) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { moods, isLoading } = useMoods(sprintId);
+
+  const chartData = useMemo(() => {
+    if (!moods) return [];
+
+    const moodsByDate: Record<string, { totalScore: number; count: number }> = {};
+    
+    // Initialize dates in sprint up to today
+    const start = dayjs(sprintStartDate);
+    const end = dayjs(sprintEndDate);
+    const today = dayjs().startOf('day');
+    const lastDate = end.isBefore(today) ? end : today;
+
+    for (let d = start; d.isSameOrBefore(lastDate); d = d.add(1, 'day')) {
+      moodsByDate[d.format('YYYY-MM-DD')] = { totalScore: 0, count: 0 };
+    }
+
+    moods.forEach((m) => {
+      const dateStr = dayjs(m.date).format('YYYY-MM-DD');
+      if (moodsByDate[dateStr]) {
+        // Map: Happy(0) -> 3, Neutral(1) -> 2, Sad(2) -> 1
+        let score = 0;
+        if (m.mood === MoodValues.Happy) score = 3;
+        else if (m.mood === MoodValues.Neutral) score = 2;
+        else if (m.mood === MoodValues.Sad) score = 1;
+        
+        moodsByDate[dateStr].totalScore += score;
+        moodsByDate[dateStr].count += 1;
+      }
+    });
+
+    return Object.entries(moodsByDate)
+      .map(([date, data]) => ({
+        date,
+        displayDate: dayjs(date).format('DD/MM'),
+        average: data.count > 0 ? parseFloat((data.totalScore / data.count).toFixed(2)) : null,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }, [moods, sprintStartDate, sprintEndDate]);
+
+  if (isLoading) {
+    return (
+      <Card sx={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <CircularProgress />
+      </Card>
+    );
+  }
+
+  return (
+    <Card sx={{ height: '100%', boxShadow: 3, borderRadius: 2 }}>
+      <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <Typography variant="h6" gutterBottom align="center">
+          {t('dashboard.teamTrend', 'Tendance de l\'équipe')}
+        </Typography>
+        
+        <Box sx={{ flexGrow: 1, minHeight: 200, mt: 2 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={chartData}>
+              <defs>
+                <linearGradient id="colorAverage" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={theme.palette.primary.main} stopOpacity={0.8} />
+                  <stop offset="95%" stopColor={theme.palette.primary.main} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis 
+                dataKey="displayDate" 
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis 
+                domain={[1, 3]} 
+                ticks={[1, 2, 3]}
+                tickFormatter={(value) => {
+                  if (value === 3) return '😊';
+                  if (value === 2) return '😐';
+                  if (value === 1) return '☹️';
+                  return '';
+                }}
+                tick={{ fontSize: 16 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip 
+                formatter={(value: number | undefined) => [value ?? 0, t('dashboard.averageMood', 'Humeur moyenne')]}
+                labelFormatter={(label) => `${t('common.date', 'Date')}: ${label}`}
+                contentStyle={{ 
+                  backgroundColor: theme.palette.background.paper, 
+                  color: theme.palette.text.primary,
+                  border: `1px solid ${theme.palette.divider}`,
+                  borderRadius: '4px'
+                }}
+              />
+              <Area
+                type="monotone"
+                dataKey="average"
+                stroke={theme.palette.primary.main}
+                fillOpacity={1}
+                fill="url(#colorAverage)"
+                connectNulls
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TeamMoodTrendWidget;

--- a/app/frontend/src/components/layout/Sidebar.tsx
+++ b/app/frontend/src/components/layout/Sidebar.tsx
@@ -134,6 +134,29 @@ const Sidebar: React.FC<SidebarProps> = ({ open, handleDrawerClose, handleDrawer
         <ListItem disablePadding sx={{ display: 'block' }}>
           <ListItemButton
             component={NavLink}
+            to="/current-sprints"
+            sx={{
+              minHeight: 48,
+              justifyContent: open ? 'initial' : 'center',
+              px: 2.5,
+            }}
+          >
+            <ListItemIcon
+              sx={{
+                minWidth: 0,
+                mr: open ? 3 : 'auto',
+                justifyContent: 'center',
+              }}
+            >
+              <TimelineIcon />
+            </ListItemIcon>
+            <ListItemText primary={t('sidebar.currentSprint')} sx={{ opacity: open ? 1 : 0 }} />
+          </ListItemButton>
+        </ListItem>
+
+        <ListItem disablePadding sx={{ display: 'block' }}>
+          <ListItemButton
+            component={NavLink}
             to="/past-sprints"
             sx={{
               minHeight: 48,

--- a/app/frontend/src/components/sprints/SprintMoodGrid.tsx
+++ b/app/frontend/src/components/sprints/SprintMoodGrid.tsx
@@ -7,18 +7,16 @@ import { Avatar, Box, Paper, Typography, useTheme } from '@mui/material';
 import dayjs from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import { useSnackbar } from 'notistack';
-import { useSWRConfig } from 'swr';
 
 import { useAuth } from '@/context/AuthContext';
+import { useMoodMutation } from '@/hooks/useMoodMutation';
 import { useMoods } from '@/hooks/useMoods';
 import type { MoodType } from '@/models/MoodType';
 import { MoodValues } from '@/models/MoodType';
-import { createMoodEntry, updateMoodEntry } from '@/services/moodService';
 
 dayjs.extend(isSameOrAfter);
 
 interface SprintMoodGridProps {
-  teamId: string;
   sprintId: string;
   sprintStartDate: Date;
   sprintEndDate: Date;
@@ -52,23 +50,17 @@ const getMoodIcon = (moodType: MoodType) => {
 };
 
 const SprintMoodGrid: React.FC<SprintMoodGridProps> = ({
-  teamId,
   sprintId,
   sprintStartDate,
   sprintEndDate,
   teamMembers,
 }) => {
   const { user } = useAuth(); // Current logged-in user
-  const { moods, mutateMoods } = useMoods(sprintId); // Fetch moods for this sprint
-  const { mutate } = useSWRConfig();
+  const { moods } = useMoods(sprintId); // Fetch moods for this sprint
+  const { saveMood } = useMoodMutation(sprintId);
   const theme = useTheme();
   const { enqueueSnackbar } = useSnackbar();
   const today = dayjs().startOf('day');
-
-  // Local state for optimistic updates (debouncing)
-  // Key: `${userId}_${dateString}`
-  const [pendingMoods, setPendingMoods] = React.useState<Record<string, MoodType>>({});
-  const timeoutsRef = React.useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   // Generate an array of dates for the sprint
   const sprintDates: Date[] = [];
@@ -79,70 +71,13 @@ const SprintMoodGrid: React.FC<SprintMoodGridProps> = ({
     day.setDate(day.getDate() + 1);
   }
 
-  const handleMoodClick = async (date: Date, moodType: MoodType) => {
+  const handleMoodClick = async (date: Date, nextMood: MoodType) => {
     if (!user) return;
-
-    const dateStr = date.toDateString();
-    const cellKey = `${user.sub}_${dateStr}`;
-    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-
-    // 1. Optimistic Update
-    setPendingMoods((prev) => ({ ...prev, [cellKey]: moodType }));
-
-    // 2. Clear existing timeout for this cell
-    if (timeoutsRef.current[cellKey]) {
-      clearTimeout(timeoutsRef.current[cellKey]);
+    try {
+      await saveMood(dayjs(date), nextMood, user.sub);
+    } catch {
+      enqueueSnackbar('Failed to save mood entry.', { variant: 'error' });
     }
-
-    // 3. Set new timeout for API call
-    timeoutsRef.current[cellKey] = setTimeout(async () => {
-      try {
-        // Check if there was an ORIGINAL entry before we started messing with it locally
-        // We look at the 'moods' from SWR (server state) to decide Create vs Update
-        const existingMood = moods?.find(
-          (m) => m.userId === user.sub && new Date(m.date).toDateString() === dateStr,
-        );
-
-        if (existingMood) {
-          // Update existing mood
-          await updateMoodEntry({
-            mood: moodType,
-            date: utcDate.toISOString(),
-            sprintId: sprintId,
-            userId: user.sub,
-          });
-        } else {
-          // Create new mood
-          await createMoodEntry({
-            mood: moodType,
-            date: utcDate.toISOString(),
-            sprintId: sprintId,
-            userId: user.sub,
-          });
-        }
-
-        // On success:
-        mutateMoods(); // Revalidate SWR
-        mutate(`/teams/${teamId}/sprints`); // Revalidate sprints stats
-
-        // Remove from pending state (UI will now reflect SWR data)
-        setPendingMoods((prev) => {
-          const newState = { ...prev };
-          delete newState[cellKey];
-          return newState;
-        });
-      } catch {
-        enqueueSnackbar('Failed to save mood entry.', { variant: 'error' });
-        // Remove from pending state to revert UI to server state
-        setPendingMoods((prev) => {
-          const newState = { ...prev };
-          delete newState[cellKey];
-          return newState;
-        });
-      } finally {
-        delete timeoutsRef.current[cellKey];
-      }
-    }, 1000); // 1 second debounce
   };
 
   return (
@@ -234,23 +169,16 @@ const SprintMoodGrid: React.FC<SprintMoodGridProps> = ({
               </Typography>
             </Box>
             {sprintDates.map((date, dateIndex) => {
-              // Determine display data: Pending > Server > Null
-              const dateStr = date.toDateString();
-              const cellKey = `${member.id}_${dateStr}`;
-              const pendingMood = pendingMoods[cellKey];
-
-              const serverMoodEntry = moods?.find(
-                (m) => m.userId === member.id && new Date(m.date).toDateString() === dateStr,
+              // Determine display data: Using SWR cache (which is optimistically updated by the hook)
+              // We need to match the date logic used in the hook (startOf('day'))
+              const cellDate = dayjs(date);
+              
+              const displayMoodEntry = moods?.find(
+                (m) => m.userId === member.id && dayjs(m.date).startOf('day').isSame(cellDate.startOf('day'))
               );
 
-              // Construct a virtual mood object for display
-              const displayMoodEntry =
-                pendingMood !== undefined
-                  ? { mood: pendingMood, date: date.toISOString(), userId: member.id } // Virtual entry from pending state
-                  : serverMoodEntry;
-
-              const isFuture = dayjs(date).isAfter(today);
-              const isToday = dayjs(date).isSame(today);
+              const isFuture = cellDate.isAfter(today);
+              const isToday = cellDate.isSame(today, 'day');
               const canEdit = user && user.sub === member.id && !isFuture;
 
               return (

--- a/app/frontend/src/hooks/useMoodMutation.ts
+++ b/app/frontend/src/hooks/useMoodMutation.ts
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+
+import { useMoods } from '@/hooks/useMoods'; // To access the cache key logic if needed, or re-export types
+import type { Mood } from '@/models/Mood';
+import type { MoodType } from '@/models/MoodType';
+import { createMoodEntry, updateMoodEntry } from '@/services/moodService';
+
+export const useMoodMutation = (sprintId: string) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const { moods, mutateMoods } = useMoods(sprintId);
+
+  const saveMood = async (date: Dayjs, moodType: MoodType, userId: string) => {
+    if (isUpdating || !moods) return;
+
+    setIsUpdating(true);
+
+    // Safe Date logic: Force 12:00 UTC to avoid timezone shifts on backend
+    const safeDate = new Date(Date.UTC(date.year(), date.month(), date.date(), 12, 0, 0));
+    const safeDateStr = safeDate.toISOString();
+
+    // Find existing entry for this specific day
+    // We compare using the same logic: startOf('day') in local time or just use the backend date string if available
+    // Here we use the backend date check logic we established:
+    const existingMood = moods.find(
+      (m) => m.userId === userId && dayjs(m.date).startOf('day').isSame(date.startOf('day'))
+    );
+
+    // 1. Optimistic Data Construction
+    const optimisticMoodEntry: Mood = {
+      id: existingMood?.id ?? `opt-${Date.now()}`,
+      userId,
+      sprintId,
+      date: safeDateStr,
+      mood: moodType,
+    };
+
+    const optimisticMoodsList = existingMood
+      ? moods.map((m) => (m.id === existingMood.id ? optimisticMoodEntry : m))
+      : [...moods, optimisticMoodEntry];
+
+    // 2. Apply Optimistic Update
+    await mutateMoods(optimisticMoodsList, { revalidate: false });
+
+    try {
+      if (existingMood) {
+        await updateMoodEntry({
+          mood: moodType,
+          date: safeDateStr,
+          sprintId,
+          userId,
+        });
+      } else {
+        await createMoodEntry({
+          mood: moodType,
+          date: safeDateStr,
+          sprintId,
+          userId,
+        });
+      }
+      
+      // 3. Revalidate
+      await mutateMoods();
+      return true; // Success
+    } catch (error) {
+      console.error(error);
+      // Revert is handled by revalidation
+      await mutateMoods();
+      throw error;
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return {
+    saveMood,
+    isUpdating,
+  };
+};

--- a/app/frontend/src/hooks/useTeam.ts
+++ b/app/frontend/src/hooks/useTeam.ts
@@ -1,0 +1,18 @@
+import useSWR from 'swr';
+
+import type { TeamWithMembersAndSprints } from '@/models/Team/TeamWithMembersAndSprints';
+import { getTeamById } from '@/services/teamService';
+
+export const useTeam = (teamId: string | undefined) => {
+  const { data, error, mutate, isLoading } = useSWR<TeamWithMembersAndSprints>(
+    teamId ? [`/teams/${teamId}`] : null,
+    () => getTeamById(teamId!),
+  );
+
+  return {
+    team: data,
+    isLoading,
+    isError: error,
+    mutate,
+  };
+};

--- a/app/frontend/src/i18n/locales/en.json
+++ b/app/frontend/src/i18n/locales/en.json
@@ -21,6 +21,7 @@
   },
   "sidebar": {
     "home": "Home",
+    "currentSprint": "Current Sprints",
     "pastSprints": "Past Sprints",
     "admin": "Administration",
     "teams": "Teams",
@@ -45,7 +46,18 @@
     "noActiveSprint": "No active sprint found for this team.",
     "editTeamName": "Edit team name",
     "teamUpdated": "Team name updated successfully.",
-    "teamUpdateFailed": "Failed to update team name."
+    "teamUpdateFailed": "Failed to update team name.",
+    "viewFullBoard": "View Full Board",
+    "howAreYouToday": "How are you today?",
+    "selectDate": "Select a date",
+    "moodRecorded": "Mood recorded for this day",
+    "teamTrend": "Team Trend",
+    "averageMood": "Average Mood"
+  },
+  "mood": {
+    "happy": "Happy",
+    "neutral": "Neutral",
+    "sad": "Sad"
   },
   "adminTeams": {
     "title": "Admin Teams",

--- a/app/frontend/src/i18n/locales/en.json
+++ b/app/frontend/src/i18n/locales/en.json
@@ -13,6 +13,7 @@
     "actions": "Actions",
     "copyLink": "Copy Link",
     "date": "Date",
+    "noData": "No data available",
     "logoutDialog": {
       "title": "Confirm Logout",
       "content": "Are you sure you want to log out?",

--- a/app/frontend/src/i18n/locales/fr.json
+++ b/app/frontend/src/i18n/locales/fr.json
@@ -21,6 +21,7 @@
   },
   "sidebar": {
     "home": "Accueil",
+    "currentSprint": "Sprints en cours",
     "pastSprints": "Sprints Passés",
     "admin": "Administration",
     "teams": "Équipes",
@@ -45,7 +46,18 @@
     "noActiveSprint": "Aucun sprint actif trouvé pour cette équipe.",
     "editTeamName": "Modifier le nom de l'équipe",
     "teamUpdated": "Nom de l'équipe mis à jour avec succès.",
-    "teamUpdateFailed": "Échec de la mise à jour du nom de l'équipe."
+    "teamUpdateFailed": "Échec de la mise à jour du nom de l'équipe.",
+    "viewFullBoard": "Voir le tableau complet",
+    "howAreYouToday": "Comment allez-vous ?",
+    "selectDate": "Sélectionner une date",
+    "moodRecorded": "Humeur enregistrée pour ce jour",
+    "teamTrend": "Tendance de l'équipe",
+    "averageMood": "Humeur moyenne"
+  },
+  "mood": {
+    "happy": "Heureux",
+    "neutral": "Neutre",
+    "sad": "Triste"
   },
   "adminTeams": {
     "title": "Administration des Équipes",

--- a/app/frontend/src/i18n/locales/fr.json
+++ b/app/frontend/src/i18n/locales/fr.json
@@ -13,6 +13,7 @@
     "actions": "Actions",
     "copyLink": "Copier le lien",
     "date": "Date",
+    "noData": "Pas de données disponibles",
     "logoutDialog": {
       "title": "Confirmer la déconnexion",
       "content": "Êtes-vous sûr de vouloir vous déconnecter ?",

--- a/app/frontend/src/pages/CurrentSprintsPage.tsx
+++ b/app/frontend/src/pages/CurrentSprintsPage.tsx
@@ -1,0 +1,175 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import EditIcon from '@mui/icons-material/Edit';
+import FaceIcon from '@mui/icons-material/Face';
+// Material UI Imports
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import { useSnackbar } from 'notistack';
+
+import { useAuth } from '@/context/AuthContext';
+import useSprints from '@/hooks/useSprints';
+import useTeams from '@/hooks/useTeams';
+import type { Sprint } from '@/models/Sprint';
+import type { TeamWithMembersAndSprints } from '@/models/Team/TeamWithMembersAndSprints';
+import { transferTeamAdmin, updateTeam } from '@/services/teamService';
+
+import EditTeamDialog from '@/components/EditTeamDialog';
+import PageContainer from '@/components/layout/PageContainer';
+import SprintMoodGrid from '@/components/sprints/SprintMoodGrid';
+
+const CurrentSprintsPage: React.FC = () => {
+  const { t } = useTranslation();
+  const { teams, isLoading: isLoadingTeams, isError: isErrorTeams, mutate } = useTeams();
+
+  if (isLoadingTeams) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '80vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isErrorTeams) {
+    return <Typography color="error">{t('dashboard.failedLoadTeams')}</Typography>;
+  }
+
+  return (
+    <PageContainer title={t('dashboard.currentSprint')} icon={<DashboardIcon />}>
+      {teams && teams.length > 0 ? (
+        teams.map((team: TeamWithMembersAndSprints) => (
+          <TeamCurrentSprintSection key={team.id} team={team} onUpdate={() => mutate()} />
+        ))
+      ) : (
+        <Typography variant="body1">{t('dashboard.noTeams')}</Typography>
+      )}
+    </PageContainer>
+  );
+};
+
+interface TeamCurrentSprintSectionProps {
+  team: TeamWithMembersAndSprints;
+  onUpdate: () => void;
+}
+
+const TeamCurrentSprintSection: React.FC<TeamCurrentSprintSectionProps> = ({ team, onUpdate }) => {
+  const { t } = useTranslation();
+  const { isSuperAdmin, userTeamRoles } = useAuth();
+  const { sprints, isLoading: isLoadingSprints, isError: isErrorSprints } = useSprints(team.id);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const { enqueueSnackbar } = useSnackbar();
+
+  const isTeamAdmin = isSuperAdmin || userTeamRoles[team.id]?.isAdmin;
+
+  if (isLoadingSprints) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isErrorSprints) {
+    return <Typography color="error">{t('common.error')}</Typography>;
+  }
+
+  const handleUpdateName = async (newName: string) => {
+    try {
+      await updateTeam(team.id, newName);
+      enqueueSnackbar(t('dashboard.teamUpdated'), { variant: 'success' });
+      onUpdate();
+    } catch {
+      enqueueSnackbar(t('dashboard.teamUpdateFailed'), { variant: 'error' });
+      throw new Error('Update failed');
+    }
+  };
+
+  const handleTransferAdmin = async (newAdminId: string) => {
+    try {
+      await transferTeamAdmin(team.id, newAdminId);
+      enqueueSnackbar(t('adminTeams.teamAdminTransferred'), { variant: 'success' });
+      onUpdate();
+    } catch {
+      enqueueSnackbar(t('adminTeams.teamAdminTransferFailed'), { variant: 'error' });
+      throw new Error('Transfer failed');
+    }
+  };
+
+  const currentSprint = sprints?.find((sprint: Sprint) => {
+    const today = new Date();
+    const startDate = new Date(sprint.startDate);
+    const endDate = new Date(sprint.endDate);
+    return today >= startDate && today <= endDate;
+  });
+
+  return (
+    <Card key={team.id} sx={{ mb: 4, p: 2, boxShadow: 3 }}>
+      <CardContent>
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="h5" component="h2" gutterBottom sx={{ mb: 0 }}>
+              {team.name}
+            </Typography>
+            {isTeamAdmin && (
+              <IconButton
+                size="small"
+                onClick={() => setIsEditDialogOpen(true)}
+                title={t('dashboard.editTeamName')}
+                sx={{ color: 'text.secondary' }}
+              >
+                <EditIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Box>
+          <Chip
+            icon={<FaceIcon />}
+            label={t('dashboard.owner', { name: team.adminName })}
+            variant="outlined"
+            size="small"
+            color="primary"
+          />
+        </Box>
+        {currentSprint ? (
+          <Box>
+            <Typography variant="subtitle1" color="text.secondary">
+              {currentSprint.name} ({new Date(currentSprint.startDate).toLocaleDateString()} -{' '}
+              {new Date(currentSprint.endDate).toLocaleDateString()})
+            </Typography>
+            <Box sx={{ overflowX: 'auto', pb: 2, mt: 2 }}>
+              <SprintMoodGrid
+                sprintId={currentSprint.id}
+                sprintStartDate={new Date(currentSprint.startDate)}
+                sprintEndDate={new Date(currentSprint.endDate)}
+                teamMembers={team.members}
+              />
+            </Box>
+          </Box>
+        ) : (
+          <Typography variant="body2">{t('dashboard.noActiveSprint')}</Typography>
+        )}
+      </CardContent>
+
+      <EditTeamDialog
+        open={isEditDialogOpen}
+        onClose={() => setIsEditDialogOpen(false)}
+        onUpdate={handleUpdateName}
+        currentName={team.name}
+        members={team.members}
+        currentAdminId={team.adminId}
+        onTransfer={handleTransferAdmin}
+      />
+    </Card>
+  );
+};
+
+export default CurrentSprintsPage;

--- a/app/frontend/src/pages/DashboardPage.tsx
+++ b/app/frontend/src/pages/DashboardPage.tsx
@@ -1,34 +1,30 @@
-import React, { useState } from 'react';
+import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import DashboardIcon from '@mui/icons-material/Dashboard';
-import EditIcon from '@mui/icons-material/Edit';
-import FaceIcon from '@mui/icons-material/Face';
 // Material UI Imports
 import {
   Box,
-  Card,
-  CardContent,
-  Chip,
+  Button,
   CircularProgress,
-  IconButton,
+  Grid,
   Typography,
 } from '@mui/material';
-import { useSnackbar } from 'notistack';
 
-import { useAuth } from '@/context/AuthContext';
 import useSprints from '@/hooks/useSprints';
 import useTeams from '@/hooks/useTeams';
 import type { Sprint } from '@/models/Sprint';
 import type { TeamWithMembersAndSprints } from '@/models/Team/TeamWithMembersAndSprints';
-import { transferTeamAdmin,updateTeam } from '@/services/teamService';
 
-import EditTeamDialog from '@/components/EditTeamDialog';
+import DailyMoodWidget from '@/components/dashboard/DailyMoodWidget';
 import PageContainer from '@/components/layout/PageContainer';
-import SprintMoodGrid from '@/components/sprints/SprintMoodGrid';
+
+const TeamMoodTrendWidget = React.lazy(() => import('@/components/dashboard/TeamMoodTrendWidget'));
 
 const DashboardPage: React.FC = () => {
   const { t } = useTranslation();
-  const { teams, isLoading: isLoadingTeams, isError: isErrorTeams, mutate } = useTeams();
+  const { teams, isLoading: isLoadingTeams, isError: isErrorTeams } = useTeams();
 
   if (isLoadingTeams) {
     return (
@@ -46,7 +42,7 @@ const DashboardPage: React.FC = () => {
     <PageContainer title={t('dashboard.title')} icon={<DashboardIcon />}>
       {teams && teams.length > 0 ? (
         teams.map((team: TeamWithMembersAndSprints) => (
-          <TeamDashboardSection key={team.id} team={team} onUpdate={() => mutate()} />
+          <TeamDashboardSection key={team.id} team={team} />
         ))
       ) : (
         <Typography variant="body1">{t('dashboard.noTeams')}</Typography>
@@ -57,17 +53,11 @@ const DashboardPage: React.FC = () => {
 
 interface TeamDashboardSectionProps {
   team: TeamWithMembersAndSprints;
-  onUpdate: () => void;
 }
 
-const TeamDashboardSection: React.FC<TeamDashboardSectionProps> = ({ team, onUpdate }) => {
+const TeamDashboardSection: React.FC<TeamDashboardSectionProps> = ({ team }) => {
   const { t } = useTranslation();
-  const { isSuperAdmin, userTeamRoles } = useAuth();
   const { sprints, isLoading: isLoadingSprints, isError: isErrorSprints } = useSprints(team.id);
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-  const { enqueueSnackbar } = useSnackbar();
-
-  const isTeamAdmin = isSuperAdmin || userTeamRoles[team.id]?.isAdmin;
 
   if (isLoadingSprints) {
     return (
@@ -78,35 +68,8 @@ const TeamDashboardSection: React.FC<TeamDashboardSectionProps> = ({ team, onUpd
   }
 
   if (isErrorSprints) {
-    // Note: You might want to add a specific error key for sprints or reuse a generic one with dynamic content if supported/needed.
-    // For now keeping it simple or reusing a generic error if applicable, or leaving untranslated if specific key missing.
-    // Let's assume we want to translate it roughly or stick to English if key missing.
-    // I will use a generic error message for now to be safe or leave hardcoded if critical.
-    // Given the plan, let's use a generic error or add a specific key if I can. I added 'error' in common.
     return <Typography color="error">{t('common.error')}</Typography>;
   }
-
-  const handleUpdateName = async (newName: string) => {
-    try {
-      await updateTeam(team.id, newName);
-      enqueueSnackbar(t('dashboard.teamUpdated'), { variant: 'success' });
-      onUpdate();
-    } catch {
-      enqueueSnackbar(t('dashboard.teamUpdateFailed'), { variant: 'error' });
-      throw new Error('Update failed');
-    }
-  };
-
-  const handleTransferAdmin = async (newAdminId: string) => {
-    try {
-      await transferTeamAdmin(team.id, newAdminId);
-      enqueueSnackbar(t('adminTeams.teamAdminTransferred'), { variant: 'success' });
-      onUpdate();
-    } catch {
-      enqueueSnackbar(t('adminTeams.teamAdminTransferFailed'), { variant: 'error' });
-      throw new Error('Transfer failed');
-    }
-  };
 
   const currentSprint = sprints?.find((sprint: Sprint) => {
     const today = new Date();
@@ -116,65 +79,79 @@ const TeamDashboardSection: React.FC<TeamDashboardSectionProps> = ({ team, onUpd
   });
 
   return (
-    <Card key={team.id} sx={{ mb: 4, p: 2, boxShadow: 3 }}>
-      <CardContent>
-        <Box
-          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}
-        >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant="h5" component="h2" gutterBottom sx={{ mb: 0 }}>
-              {team.name} - {t('dashboard.currentSprint')}
-            </Typography>
-            {isTeamAdmin && (
-              <IconButton
-                size="small"
-                onClick={() => setIsEditDialogOpen(true)}
-                title={t('dashboard.editTeamName')}
-                sx={{ color: 'text.secondary' }}
-              >
-                <EditIcon fontSize="small" />
-              </IconButton>
-            )}
-          </Box>
-          <Chip
-            icon={<FaceIcon />}
-            label={t('dashboard.owner', { name: team.adminName })}
-            variant="outlined"
-            size="small"
-            color="primary"
-          />
-        </Box>
-        {currentSprint ? (
-          <Box>
+    <Box sx={{ mb: 6 }}>
+      {/* Unified Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          borderBottom: 1,
+          borderColor: 'divider',
+          pb: 1,
+          mb: 3,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 2, flexWrap: 'wrap' }}>
+          <Typography variant="h5" fontWeight="bold">
+            {team.name}
+          </Typography>
+          {currentSprint && (
             <Typography variant="subtitle1" color="text.secondary">
-              ({new Date(currentSprint.startDate).toLocaleDateString()} -{' '}
-              {new Date(currentSprint.endDate).toLocaleDateString()})
+              {currentSprint.name}
+              <Typography component="span" variant="caption" sx={{ ml: 1 }}>
+                ({new Date(currentSprint.startDate).toLocaleDateString()} -{' '}
+                {new Date(currentSprint.endDate).toLocaleDateString()})
+              </Typography>
             </Typography>
-            <Box sx={{ overflowX: 'auto', pb: 2 }}>
-              <SprintMoodGrid
-                teamId={team.id}
-                sprintId={currentSprint.id}
-                sprintStartDate={new Date(currentSprint.startDate)}
-                sprintEndDate={new Date(currentSprint.endDate)}
-                teamMembers={team.members}
-              />
-            </Box>
-          </Box>
-        ) : (
-          <Typography variant="body2">{t('dashboard.noActiveSprint')}</Typography>
+          )}
+        </Box>
+        {currentSprint && (
+          <Button
+            component={RouterLink}
+            to={`/teams/${team.id}/sprints/${currentSprint.id}`}
+            endIcon={<ArrowForwardIcon />}
+            size="small"
+            color="inherit"
+            sx={{ textTransform: 'none' }}
+          >
+            {t('dashboard.viewFullBoard', 'Voir le tableau complet')}
+          </Button>
         )}
-      </CardContent>
+      </Box>
 
-      <EditTeamDialog
-        open={isEditDialogOpen}
-        onClose={() => setIsEditDialogOpen(false)}
-        onUpdate={handleUpdateName}
-        currentName={team.name}
-        members={team.members}
-        currentAdminId={team.adminId}
-        onTransfer={handleTransferAdmin}
-      />
-    </Card>
+      {/* Widgets Content */}
+      {currentSprint ? (
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 5 }}>
+            <DailyMoodWidget
+              sprintId={currentSprint.id}
+              sprintStartDate={currentSprint.startDate}
+              sprintEndDate={currentSprint.endDate}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 7 }}>
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+                  <CircularProgress />
+                </Box>
+              }
+            >
+              <TeamMoodTrendWidget
+                sprintId={currentSprint.id}
+                sprintStartDate={currentSprint.startDate}
+                sprintEndDate={currentSprint.endDate}
+              />
+            </Suspense>
+          </Grid>
+        </Grid>
+      ) : (
+        <Typography variant="body1" sx={{ py: 4, textAlign: 'center', color: 'text.secondary' }}>
+          {t('dashboard.noActiveSprint')}
+        </Typography>
+      )}
+    </Box>
   );
 };
 

--- a/app/frontend/src/pages/DashboardPage.tsx
+++ b/app/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -18,9 +18,8 @@ import type { Sprint } from '@/models/Sprint';
 import type { TeamWithMembersAndSprints } from '@/models/Team/TeamWithMembersAndSprints';
 
 import DailyMoodWidget from '@/components/dashboard/DailyMoodWidget';
+import TeamMoodTrendWidget from '@/components/dashboard/TeamMoodTrendWidget';
 import PageContainer from '@/components/layout/PageContainer';
-
-const TeamMoodTrendWidget = React.lazy(() => import('@/components/dashboard/TeamMoodTrendWidget'));
 
 const DashboardPage: React.FC = () => {
   const { t } = useTranslation();
@@ -131,19 +130,11 @@ const TeamDashboardSection: React.FC<TeamDashboardSectionProps> = ({ team }) => 
             />
           </Grid>
           <Grid size={{ xs: 12, md: 7 }}>
-            <Suspense
-              fallback={
-                <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-                  <CircularProgress />
-                </Box>
-              }
-            >
-              <TeamMoodTrendWidget
-                sprintId={currentSprint.id}
-                sprintStartDate={currentSprint.startDate}
-                sprintEndDate={currentSprint.endDate}
-              />
-            </Suspense>
+            <TeamMoodTrendWidget
+              sprintId={currentSprint.id}
+              sprintStartDate={currentSprint.startDate}
+              sprintEndDate={currentSprint.endDate}
+            />
           </Grid>
         </Grid>
       ) : (

--- a/app/frontend/src/pages/SprintDetailsPage.tsx
+++ b/app/frontend/src/pages/SprintDetailsPage.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import { Box, Breadcrumbs, CircularProgress, Link,Typography } from '@mui/material';
+
+import { useSprint } from '@/hooks/useSprint';
+import { useTeam } from '@/hooks/useTeam';
+
+import PageContainer from '@/components/layout/PageContainer';
+import SprintMoodGrid from '@/components/sprints/SprintMoodGrid';
+
+const SprintDetailsPage: React.FC = () => {
+  const { t } = useTranslation();
+  const { teamId, sprintId } = useParams<{ teamId: string; sprintId: string }>();
+
+  const { team, isLoading: isLoadingTeam, isError: isErrorTeam } = useTeam(teamId);
+  const { sprint, isLoading: isLoadingSprint, isError: isErrorSprint } = useSprint(sprintId ?? null);
+
+  if (isLoadingTeam || isLoadingSprint) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '80vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isErrorTeam || isErrorSprint || !team || !sprint) {
+    return (
+      <PageContainer title={t('common.error')}>
+        <Typography color="error">{t('dashboard.failedLoadTeams')}</Typography>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer title={`${team.name} - ${sprint.name}`} icon={<DashboardIcon />}>
+      <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 3 }}>
+        <Link component={RouterLink} underline="hover" color="inherit" to="/my-teams">
+          {t('dashboard.title')}
+        </Link>
+        <Typography color="text.primary">{sprint.name}</Typography>
+      </Breadcrumbs>
+
+      <Box sx={{ mt: 2 }}>
+        <Typography variant="h6" gutterBottom>
+          {new Date(sprint.startDate).toLocaleDateString()} - {new Date(sprint.endDate).toLocaleDateString()}
+        </Typography>
+        <Box sx={{ overflowX: 'auto', pb: 2, mt: 3 }}>
+          <SprintMoodGrid
+            sprintId={sprint.id}
+            sprintStartDate={new Date(sprint.startDate)}
+            sprintEndDate={new Date(sprint.endDate)}
+            teamMembers={team.members}
+          />
+        </Box>
+      </Box>
+    </PageContainer>
+  );
+};
+
+export default SprintDetailsPage;

--- a/app/frontend/src/services/teamService.ts
+++ b/app/frontend/src/services/teamService.ts
@@ -10,6 +10,11 @@ export const getTeams = async (): Promise<TeamWithMembersAndSprints[]> => {
   return data;
 };
 
+export const getTeamById = async (teamId: string): Promise<TeamWithMembersAndSprints> => {
+  const { data } = await api.get(`/teams/${teamId}`);
+  return data;
+};
+
 export const createTeam = async (team: CreateTeam): Promise<TeamDto> => {
   const { data } = await api.post('/teams', team);
   return data;


### PR DESCRIPTION
- Redesigned homepage with a transparent layout and unified headers.
- Added DailyMoodWidget for prominent mood entry with optimistic updates.
- Added TeamMoodTrendWidget using Recharts with lazy loading for optimization.
- Moved the full sprint grid to a dedicated SprintDetailsPage.
- Re-introduced "Current Sprints" view with team management capabilities.
- Fixed dark mode visibility for charts and tooltips.
- Added `useMoodMutation` hook to centralize and secure mood persistence logic (UTC noon fix).
- Improved visual feedback and enlarged emojis for daily mood selection.
- Updated translations (fr/en) and routing.
- Removed recharts dependency, reducing bundle size by ~330kB.
- Implemented hand-crafted SVG trend line with Bezier curve smoothing.
- Used HTML overlays for dots and labels to ensure roundness and perfect alignment.
- Fixed tooltip clipping using MUI Popper (Portal).
- Removed lazy loading for the now lightweight trend widget.
- Added missing translations for empty data states.