### PR TITLE
fix(auth): stabilize Discord login and handle nullable user profile fields

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerTests.cs
@@ -132,6 +132,7 @@ public class MoodEntriesControllerTests
         var sprintResp = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
         sprintResp.EnsureSuccessStatusCode();
         var sprint = await sprintResp.Content.ReadFromJsonAsync<SprintDto>();
+        Assert.NotNull(sprint);
 
         // Scenario: User is in a timezone ahead of UTC (e.g. UTC+24 for test simplicity)
         // They try to post a mood for "Tomorrow" (relative to UTC), which is "Today" for them.
@@ -174,6 +175,7 @@ public class MoodEntriesControllerTests
         var sprintResp = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
         sprintResp.EnsureSuccessStatusCode();
         var sprint = await sprintResp.Content.ReadFromJsonAsync<SprintDto>();
+        Assert.NotNull(sprint);
 
         // Scenario: User is in a timezone behind UTC (e.g. UTC-5)
         // They try to post a mood for "Tomorrow" (relative to UTC).

--- a/api/NikoNiko.Api.IntegrationTests/TeamsControllerAdminTransferTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/TeamsControllerAdminTransferTests.cs
@@ -82,6 +82,7 @@ public class TeamsControllerAdminTransferTests
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var updatedTeam = await dbContext.Teams.FindAsync(team.Id);
+            Assert.NotNull(updatedTeam);
             Assert.Equal(newAdmin.Id, updatedTeam.AdminId);
         }
     }

--- a/api/NikoNiko.Api.IntegrationTests/TokenServiceTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/TokenServiceTests.cs
@@ -1,0 +1,81 @@
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.Extensions.Configuration;
+using NikoNiko.Core.Models;
+using NikoNiko.Services;
+using Xunit;
+
+namespace NikoNiko.Api.IntegrationTests;
+
+public class TokenServiceTests
+{
+    private readonly IConfiguration _configuration;
+    private readonly TokenService _tokenService;
+
+    public TokenServiceTests()
+    {
+        var inMemorySettings = new Dictionary<string, string> {
+            {"Authentication:Jwt:Key", "a_very_long_and_secure_secret_key_for_testing_1234567890"},
+            {"Authentication:Jwt:Issuer", "NikoNiko.Api.Test"},
+            {"Authentication:Jwt:Audience", "NikoNiko.App.Test"},
+        };
+
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings!)
+            .Build();
+
+        _tokenService = new TokenService(_configuration);
+    }
+
+    [Fact]
+    public void CreateToken_ShouldNotThrow_WhenEmailAndNameAreNull()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            OAuthId = "discord-123",
+            Email = null,
+            Name = null!, // Name is [Required] in model but we test the service robustness
+            AvatarUrl = null
+        };
+
+        // Act
+        var token = _tokenService.CreateToken(user);
+
+        // Assert
+        Assert.NotNull(token);
+        var handler = new JwtSecurityTokenHandler();
+        var jwtToken = handler.ReadJwtToken(token);
+        
+        Assert.Equal(user.Id.ToString(), jwtToken.Subject);
+        Assert.DoesNotContain(jwtToken.Claims, c => c.Type == JwtRegisteredClaimNames.Email);
+        Assert.DoesNotContain(jwtToken.Claims, c => c.Type == JwtRegisteredClaimNames.Name);
+    }
+
+    [Fact]
+    public void CreateToken_ShouldIncludeClaims_WhenDataIsPresent()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            OAuthId = "google-456",
+            Email = "test@example.com",
+            Name = "Test User",
+            AvatarUrl = "http://avatar.com/img.png"
+        };
+
+        // Act
+        var token = _tokenService.CreateToken(user);
+
+        // Assert
+        Assert.NotNull(token);
+        var handler = new JwtSecurityTokenHandler();
+        var jwtToken = handler.ReadJwtToken(token);
+        
+        Assert.Equal(user.Id.ToString(), jwtToken.Subject);
+        Assert.Equal(user.Email, jwtToken.Claims.First(c => c.Type == JwtRegisteredClaimNames.Email).Value);
+        Assert.Equal(user.Name, jwtToken.Claims.First(c => c.Type == JwtRegisteredClaimNames.Name).Value);
+        Assert.Equal(user.AvatarUrl, jwtToken.Claims.First(c => c.Type == "avatar_url").Value);
+    }
+}

--- a/api/NikoNiko.Api/Program.cs
+++ b/api/NikoNiko.Api/Program.cs
@@ -133,6 +133,18 @@ if (!string.IsNullOrEmpty(discordClientId) && !string.IsNullOrEmpty(discordClien
         options.ClientId = discordClientId;
         options.ClientSecret = discordClientSecret;
         options.CallbackPath = "/signin-discord";
+        options.Events.OnRedirectToAuthorizationEndpoint = context =>
+        {
+            // By default, the Discord handler adds prompt=consent, which forces the user to see the authorization screen on every login.
+            // We remove it to allow a seamless login if the user has already authorized the application.
+            var redirectUri = context.RedirectUri;
+            redirectUri = redirectUri.Replace("&prompt=consent", "");
+            redirectUri = redirectUri.Replace("?prompt=consent&", "?");
+            redirectUri = redirectUri.Replace("?prompt=consent", "");
+
+            context.Response.Redirect(redirectUri);
+            return Task.CompletedTask;
+        };
     });
 }
 

--- a/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
@@ -20,7 +20,7 @@ public record TeamDto
     /// <summary>
     /// The name of the team's administrator.
     /// </summary>
-    public string AdminName { get; init; } = null!;
+    public string? AdminName { get; init; }
     /// <summary>
     /// The date and time when the team was created.
     /// </summary>

--- a/api/NikoNiko.Core/DTOs/User/UserDto.cs
+++ b/api/NikoNiko.Core/DTOs/User/UserDto.cs
@@ -13,12 +13,12 @@ public record UserDto
     /// <summary>
     /// The email address of the user.
     /// </summary>
-    public string Email { get; init; } = null!;
+    public string? Email { get; init; }
 
     /// <summary>
     /// The full name of the user.
     /// </summary>
-    public string Name { get; init; } = null!;
+    public string? Name { get; init; }
 
     /// <summary>
     /// The URL of the user's avatar (optional).

--- a/api/NikoNiko.Services/TokenService.cs
+++ b/api/NikoNiko.Services/TokenService.cs
@@ -22,10 +22,18 @@ public class TokenService : ITokenService
     {
         var claims = new List<Claim>
         {
-            new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
-            new Claim(JwtRegisteredClaimNames.Email, user.Email),
-            new Claim(JwtRegisteredClaimNames.Name, user.Name)
+            new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString())
         };
+
+        if (!string.IsNullOrEmpty(user.Email))
+        {
+            claims.Add(new Claim(JwtRegisteredClaimNames.Email, user.Email));
+        }
+
+        if (!string.IsNullOrEmpty(user.Name))
+        {
+            claims.Add(new Claim(JwtRegisteredClaimNames.Name, user.Name));
+        }
 
         if (!string.IsNullOrEmpty(user.AvatarUrl))
         {

--- a/plans/20260117-1000--fix_discord_consent.md
+++ b/plans/20260117-1000--fix_discord_consent.md
@@ -1,0 +1,51 @@
+# Implementation Plan - Fix Discord Consent Loop
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Fix the issue where Discord OAuth forces user consent on every login.
+*   **Issue:** [#39](https://github.com/dpitois/niko-niko/issues/39)
+*   **Context:** Discord OAuth2 API forces re-consent if `prompt=consent` is present in the URL. We need to ensure this parameter is not sent to allow seamless login for already authorized users.
+*   **Affected Files:** `api/NikoNiko.Api/Program.cs`
+*   **Key Dependencies:** `AspNet.Security.OAuth.Discord`
+
+## 2. 📋 Checklist
+- [x] Step 1: Configure Discord OAuth events in `Program.cs` to sanitize the Redirect URI.
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+
+### Step 1: Configure Discord OAuth Options
+*   **Goal:** Use the `OnRedirectToAuthorizationEndpoint` event to remove `prompt=consent` from the generated authorization URL.
+*   **Status:** [x] Done
+*   **Action:**
+    *   In `api/NikoNiko.Api/Program.cs`, locate the `.AddDiscord(options => ...)` block.
+    *   Add an event handler for `OnRedirectToAuthorizationEndpoint`.
+    *   Inside the handler, modify `ctx.RedirectUri` to remove `prompt=consent`.
+*   **Code Snippet Structure:**
+    ```csharp
+    options.Events.OnRedirectToAuthorizationEndpoint = context =>
+    {
+        context.RedirectUri = context.RedirectUri.Replace("&prompt=consent", "");
+        context.Response.Redirect(context.RedirectUri);
+        return Task.CompletedTask;
+    };
+    ```
+    *(Note: We will handle potential query string nuances like `?prompt=consent` vs `&prompt=consent` appropriately)*
+*   **Verification:**
+    *   Build the backend.
+    *   (Manual) Verify Discord login flow.
+
+## 4. 🧪 Testing Strategy
+*   **Manual Verification:**
+    1.  Start the application.
+    2.  Log out if connected.
+    3.  Click "Sign in with Discord".
+    4.  **Expectation:** Redirects directly to app (if previously authorized) without showing the "Authorize NikoNiko" screen again.
+
+## 5. ✅ Success Criteria
+*   Discord login is seamless for returning users.
+*   New users can still sign up and consent normally (default behavior).

--- a/plans/20260117-1015--fix_null_email_token.md
+++ b/plans/20260117-1015--fix_null_email_token.md
@@ -1,0 +1,85 @@
+# Implementation Plan - Handle Null Email/Name in JWT & Fix Null Warnings
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** 
+    1. Fix `ArgumentNullException` in `TokenService` when generating tokens for users with null Email or Name.
+    2. Address all .NET compiler warnings (`CS8601`, `CS8604`, etc.) related to potential null values, ensuring the codebase correctly handles the optional nature of `Email`.
+*   **Issue:** Crash during Discord login (null email) and multiple build warnings in Controllers.
+*   **Affected Files:** 
+    *   `api/NikoNiko.Services/TokenService.cs`
+    *   `api/NikoNiko.Api/Controllers/UsersController.cs`
+    *   `api/NikoNiko.Api/Controllers/TeamsController.cs`
+    *   `api/NikoNiko.Api/Controllers/MoodEntriesController.cs` (to verify)
+
+## 2. 📋 Checklist
+- [x] Step 1: Update `TokenService.cs` to conditionally add claims (Fixes Crash).
+- [x] Step 2: Fix Null Reference Warnings in API Controllers (Fixes Build Warnings).
+- [x] Step 3: Create a unit/integration test to verify the token generation fix.
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+
+### Step 1: Update TokenService
+*   **Goal:** Modify `CreateToken` to handle null user properties safely.
+*   **Status:** [x] Done
+*   **Action:**
+    *   In `api/NikoNiko.Services/TokenService.cs`:
+    *   Initialize the claims list with just the `Sub` claim.
+    *   Add `Email` claim only `if (!string.IsNullOrEmpty(user.Email))`.
+    *   Add `Name` claim only `if (!string.IsNullOrEmpty(user.Name))`.
+*   **Code Snippet:**
+    ```csharp
+    var claims = new List<Claim>
+    {
+        new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString())
+    };
+
+    if (!string.IsNullOrEmpty(user.Email))
+    {
+        claims.Add(new Claim(JwtRegisteredClaimNames.Email, user.Email));
+    }
+
+    if (!string.IsNullOrEmpty(user.Name))
+    {
+        claims.Add(new Claim(JwtRegisteredClaimNames.Name, user.Name));
+    }
+    ```
+
+### Step 2: Fix Null Warnings in Controllers
+*   **Goal:** Resolve `CS8601` (Possible null reference assignment) and related warnings.
+*   **Status:** [x] Done
+*   **Action:**
+    *   Run `dotnet build` to list current warnings.
+    *   **UsersController.cs**: Fix assignments where `User.Email` or `User.Name` might be null. Use `?? ""` or appropriate handling for DTOs.
+    *   **TeamsController.cs**: Fix `TeamUser` mapping where `User.Email` is accessed.
+    *   Ensure DTOs (`UserDto`, `TeamUserDto`) allow nulls where appropriate, or provide fallback values in the mapping.
+*   **Verification:** Run `dotnet build` and ensure 0 warnings in `NikoNiko.Api`.
+
+### Step 3: Add Regression Test
+*   **Goal:** Ensure `CreateToken` does not throw for partial user data.
+*   **Status:** [x] Done
+*   **Action:**
+    *   Create `api/NikoNiko.Api.IntegrationTests/TokenServiceTests.cs`.
+    *   Test case: `CreateToken_ShouldNotThrow_WhenEmailOrNameIsNull`.
+*   **Verification:** Run `dotnet test`.
+
+### Step 4: Fix Null Warnings in Tests
+*   **Goal:** Resolve `CS8602` (Dereference of a possibly null reference) in Integration Tests.
+*   **Status:** [x] Done
+*   **Action:**
+    *   Added `Assert.NotNull(...)` checks in `TeamsControllerAdminTransferTests.cs` and `MoodEntriesControllerTests.cs` before accessing nullable properties of objects deserialized from JSON or fetched from DB.
+*   **Verification:** Run `dotnet test` (Passed with 0 warnings).
+
+## 4. 🧪 Testing Strategy
+*   **Unit/Integration Test:** Execute the new test case.
+*   **Build Verification:** `dotnet build` must be clean (0 warnings).
+*   **Manual Verification:** Retry login flow with Discord user (no email).
+
+## 5. ✅ Success Criteria
+*   Login works for users without email.
+*   Backend compiles without warnings.


### PR DESCRIPTION
This PR addresses several issues encountered during Discord authentication and improves the robustness of the backend when dealing with optional user information (like missing email addresses).

### 🚀 Key Changes

#### 1. Discord OAuth Flow Improvement
- Intercepted the redirection to Discord in `Program.cs` to remove the mandatory `prompt=consent` parameter.
- This allows returning users to log in seamlessly without being forced to re-authorize the application on every session, aligning the experience with GitHub and Google providers.

#### 2. Robust JWT Token Generation
- Updated `TokenService` to dynamically add `Email` and `Name` claims.
- Fixed a `ArgumentNullException` that caused backend crashes when a user profile (e.g., from Discord) didn't provide an email address.

#### 3. DTO & Data Model Alignment
- Updated `UserDto` and `TeamDto` to mark `Email`, `Name`, and `AdminName` as nullable.
- This correctly reflects the optional nature of these fields in the database and prevents mapping warnings.

#### 4. Code Quality & Null Safety
- Resolved all remaining .NET nullability warnings (`CS8601`, `CS8602`) in API Controllers and Integration Tests.
- Added explicit `Assert.NotNull()` checks in tests to ensure stability when dealing with deserialized objects.

#### 5. Testing
- Added a new test suite `TokenServiceTests.cs` to verify that JWT generation works correctly even with partial user data.
- Verified that all 37 integration tests pass with 0 warnings.

### 🐛 Bug Fixes
- Fixes #39