### PR TITLE
feat(notifications): implement team-isolated SignalR groups

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerTests.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.TestHost;
+using Moq;
 
 using NikoNiko.Core.DTOs.Mood;
 using NikoNiko.Core.DTOs.Sprint;
@@ -16,6 +18,7 @@ using NikoNiko.Core.DTOs.Team;
 using NikoNiko.Core.DTOs.User;
 using NikoNiko.Core.Models;
 using NikoNiko.Data;
+using NikoNiko.Services;
 
 using Xunit;
 
@@ -23,6 +26,57 @@ namespace NikoNiko.Api.IntegrationTests;
 
 public class MoodEntriesControllerTests
 {
+    [Fact]
+    public async Task CreateMoodEntry_SendsNotificationWithCorrectTeamId()
+    {
+        // Arrange
+        var mockNotificationService = new Mock<INotificationService>();
+        await using var application = new NikoNikoApiTestApplication();
+        var client = application.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddScoped(_ => mockNotificationService.Object);
+            });
+        }).CreateClient();
+
+        var (user, userClient, token) = await application.CreateUserAndClient("Notified User");
+        client.DefaultRequestHeaders.Authorization = userClient.DefaultRequestHeaders.Authorization;
+
+        var team = await application.CreateTeam("Test Team", user.Id);
+        var createSprintDto = new CreateSprintDto
+        {
+            Name = "Test Sprint",
+            TeamId = team.Id,
+            StartDate = DateTime.UtcNow.Date,
+            EndDate = DateTime.UtcNow.AddDays(15)
+        };
+        var sprintResponse = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
+        sprintResponse.EnsureSuccessStatusCode();
+        var sprint = await sprintResponse.Content.ReadFromJsonAsync<SprintDto>();
+        Assert.NotNull(sprint);
+
+        var createMoodEntryDto = new CreateMoodEntryDto
+        {
+            SprintId = sprint.Id,
+            Date = DateTime.UtcNow.Date,
+            Mood = MoodType.Happy,
+            UserId = user.Id
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/moodentries", createMoodEntryDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        mockNotificationService.Verify(n => n.SendMoodNotificationAsync(
+            It.Is<string>(s => s == user.Email),
+            It.IsAny<string>(),
+            It.Is<string>(s => s == user.Id.ToString()),
+            It.Is<Guid>(g => g == team.Id)
+        ), Times.Once);
+    }
+
     [Fact]
     public async Task GetMoodEntries_AsTeamMember_ReturnsOk()
     {

--- a/api/NikoNiko.Api.IntegrationTests/TokenServiceTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/TokenServiceTests.cs
@@ -81,4 +81,37 @@ public class TokenServiceTests
         Assert.Equal(user.Name, jwtToken.Claims.First(c => c.Type == JwtRegisteredClaimNames.Name).Value);
         Assert.Equal(user.AvatarUrl, jwtToken.Claims.First(c => c.Type == "avatar_url").Value);
     }
+
+    [Fact]
+    public void CreateToken_ShouldIncludeTeamIdClaims_WhenUserHasTeams()
+    {
+        // Arrange
+        var teamId1 = Guid.NewGuid();
+        var teamId2 = Guid.NewGuid();
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            OAuthId = "github-789",
+            Email = "test@example.com",
+            Name = "Team User",
+            TeamUsers = new List<TeamUser>
+            {
+                new TeamUser { TeamId = teamId1 },
+                new TeamUser { TeamId = teamId2 }
+            }
+        };
+
+        // Act
+        var token = _tokenService.CreateToken(user);
+
+        // Assert
+        Assert.NotNull(token);
+        var handler = new JwtSecurityTokenHandler();
+        var jwtToken = handler.ReadJwtToken(token);
+
+        var teamIdClaims = jwtToken.Claims.Where(c => c.Type == "team_id").Select(c => c.Value).ToList();
+        Assert.Equal(2, teamIdClaims.Count);
+        Assert.Contains(teamId1.ToString(), teamIdClaims);
+        Assert.Contains(teamId2.ToString(), teamIdClaims);
+    }
 }

--- a/api/NikoNiko.Api/Controllers/AuthController.cs
+++ b/api/NikoNiko.Api/Controllers/AuthController.cs
@@ -414,12 +414,18 @@ public class AuthController : ControllerBase
         }
 
         // Prioritize lookup by OAuthId as email might be null or change
-        var user = await _context.Users.Include(u => u.RefreshTokens).FirstOrDefaultAsync(u => u.OAuthId == oauthId);
+        var user = await _context.Users
+            .Include(u => u.RefreshTokens)
+            .Include(u => u.TeamUsers)
+            .FirstOrDefaultAsync(u => u.OAuthId == oauthId);
 
         // Fallback for legacy users: try finding by Email if OAuthId didn't match (migration path)
         if (user == null && !string.IsNullOrEmpty(email))
         {
-            user = await _context.Users.Include(u => u.RefreshTokens).FirstOrDefaultAsync(u => u.Email == email);
+            user = await _context.Users
+                .Include(u => u.RefreshTokens)
+                .Include(u => u.TeamUsers)
+                .FirstOrDefaultAsync(u => u.Email == email);
             // If found by email but OAuthId was different/missing, update OAuthId? 
             // For safety in this refactor, we assume if OAuthId search failed, it's a new user OR a legacy user who hasn't logged in with this provider before.
             // But if we find by email, we should probably link them.

--- a/api/NikoNiko.Api/Controllers/MoodEntriesController.cs
+++ b/api/NikoNiko.Api/Controllers/MoodEntriesController.cs
@@ -197,7 +197,7 @@ public class MoodEntriesController : ControllerBase
             _context.MoodEntries.Update(existingEntry);
             await _context.SaveChangesAsync();
 
-            await _notificationService.SendMoodNotificationAsync(userEmail, notificationMessage, createMoodEntryDto.UserId.ToString());
+            await _notificationService.SendMoodNotificationAsync(userEmail, notificationMessage, createMoodEntryDto.UserId.ToString(), teamId);
 
             var updatedEntryDto = new MoodEntryDto
             {
@@ -222,7 +222,7 @@ public class MoodEntriesController : ControllerBase
             _context.MoodEntries.Add(moodEntry);
             await _context.SaveChangesAsync();
 
-            await _notificationService.SendMoodNotificationAsync(userEmail, notificationMessage, createMoodEntryDto.UserId.ToString());
+            await _notificationService.SendMoodNotificationAsync(userEmail, notificationMessage, createMoodEntryDto.UserId.ToString(), teamId);
 
             var moodEntryDto = new MoodEntryDto
             {

--- a/api/NikoNiko.Api/Controllers/TeamInvitationsController.cs
+++ b/api/NikoNiko.Api/Controllers/TeamInvitationsController.cs
@@ -19,11 +19,13 @@ namespace NikoNiko.Api.Controllers
     {
         private readonly ITeamInvitationService _teamInvitationService;
         private readonly ApplicationDbContext _context;
+        private readonly INotificationService _notificationService;
 
-        public TeamInvitationsController(ITeamInvitationService teamInvitationService, ApplicationDbContext context)
+        public TeamInvitationsController(ITeamInvitationService teamInvitationService, ApplicationDbContext context, INotificationService notificationService)
         {
             _teamInvitationService = teamInvitationService;
             _context = context;
+            _notificationService = notificationService;
         }
 
         /// <summary>
@@ -95,6 +97,7 @@ namespace NikoNiko.Api.Controllers
             try
             {
                 var acceptedInvitation = await _teamInvitationService.AcceptTeamInvitationAsync(token, userId);
+                await _notificationService.UpdateUserGroupAsync(userId.ToString(), acceptedInvitation.TeamId, true);
                 return Ok(acceptedInvitation);
             }
             catch (KeyNotFoundException ex)

--- a/api/NikoNiko.Api/Controllers/TeamsController.cs
+++ b/api/NikoNiko.Api/Controllers/TeamsController.cs
@@ -367,6 +367,9 @@ public class TeamsController : ControllerBase
 
         await _context.SaveChangesAsync();
 
+        // Remove from SignalR Group
+        await _notificationService.UpdateUserGroupAsync(userId.ToString(), teamId, false);
+
         // 3. Check if user is now an orphan (no teams left)
         var remainingTeamsCount = await _context.TeamUsers.CountAsync(tu => tu.UserId == userId);
         if (remainingTeamsCount == 0)

--- a/api/NikoNiko.Notifications.IntegrationTests/NotificationHubTests.cs
+++ b/api/NikoNiko.Notifications.IntegrationTests/NotificationHubTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -101,15 +102,107 @@ namespace NikoNiko.Notifications.IntegrationTests
             await receiverConnection.StopAsync();
         }
 
-        // Helper method to generate a JWT token for testing
-        private string GenerateTestJwtToken(string userId, IConfiguration config)
+        [Fact]
+        public async Task Connect_WithTeamClaims_ShouldSucceed()
         {
-            var claims = new[]
+            // Arrange
+            var userId = "teamUser";
+            var teamId1 = Guid.NewGuid().ToString();
+            var teamId2 = Guid.NewGuid().ToString();
+            var teamIds = new List<string> { teamId1, teamId2 };
+
+            var token = GenerateTestJwtToken(userId, _factory.Services.GetRequiredService<IConfiguration>(), teamIds);
+
+            var connection = new HubConnectionBuilder()
+                .WithUrl(new Uri(_factory.Server.BaseAddress, "notificationHub"), options =>
+                {
+                    options.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler();
+                    options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+                })
+                .Build();
+
+            // Act & Assert
+            try
+            {
+                await connection.StartAsync();
+                Assert.Equal(HubConnectionState.Connected, connection.State);
+            }
+            finally
+            {
+                await connection.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task ManageGroups_ShouldAddUserToGroup_AndAllowTargetedNotifications()
+        {
+            // Arrange
+            var userId = "dynamicUser";
+            var teamId = Guid.NewGuid();
+            var token = GenerateTestJwtToken(userId, _factory.Services.GetRequiredService<IConfiguration>());
+
+            var tcs = new TaskCompletionSource<string>();
+            var connection = new HubConnectionBuilder()
+                .WithUrl(new Uri(_factory.Server.BaseAddress, "notificationHub"), options =>
+                {
+                    options.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler();
+                    options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+                })
+                .Build();
+
+            connection.On<string, string>("ReceiveNotification", (user, message) =>
+            {
+                tcs.SetResult(message);
+            });
+
+            await connection.StartAsync();
+
+            // Act 1: Add user to group via API
+            var httpClient = _factory.CreateClient();
+            var managePayload = new
+            {
+                UserId = userId,
+                TeamId = teamId,
+                Action = "Add"
+            };
+            var manageContent = new StringContent(System.Text.Json.JsonSerializer.Serialize(managePayload), Encoding.UTF8, "application/json");
+            var manageResponse = await httpClient.PostAsync("/api/Notifications/manage-groups", manageContent);
+            manageResponse.EnsureSuccessStatusCode();
+
+            // Act 2: Send message to the group directly via HubContext (simulating what Dispatch will do in Step 4)
+            using (var scope = _factory.Services.CreateScope())
+            {
+                var hubContext = scope.ServiceProvider.GetRequiredService<IHubContext<NikoNiko.Notifications.Hubs.NotificationHub>>();
+                await hubContext.Clients.Group(teamId.ToString()).SendAsync("ReceiveNotification", "System", "Group Message");
+            }
+
+            // Assert
+            var resultTask = tcs.Task;
+            var completedTask = await Task.WhenAny(resultTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+            Assert.True(resultTask.IsCompletedSuccessfully, "User should have received the group notification.");
+            Assert.Equal("Group Message", resultTask.Result);
+
+            await connection.StopAsync();
+        }
+
+        // Helper method to generate a JWT token for testing
+        private string GenerateTestJwtToken(string userId, IConfiguration config, List<string>? teamIds = null)
+        {
+            var claims = new List<Claim>
             {
                 new Claim(ClaimTypes.NameIdentifier, userId),
                 new Claim(ClaimTypes.Name, userId),
                 new Claim(ClaimTypes.Email, $"{userId}@example.com")
             };
+
+            if (teamIds != null)
+            {
+                foreach (var teamId in teamIds)
+                {
+                    claims.Add(new Claim("team_id", teamId));
+                }
+            }
 
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Authentication:Jwt:Key"]!));
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature);

--- a/api/NikoNiko.Notifications/Controllers/NotificationsController.cs
+++ b/api/NikoNiko.Notifications/Controllers/NotificationsController.cs
@@ -25,9 +25,9 @@ namespace NikoNiko.Notifications.Controllers
         [HttpPost("dispatch")]
         public async Task<IActionResult> Dispatch([FromBody] NotificationPayload payload)
         {
-            if (payload.Type == "TeamRenamed")
+            if (payload.Type == "TeamRenamed" && payload.TeamId.HasValue)
             {
-                await _hubContext.Clients.All.SendAsync("ReceiveTeamRenamed", payload.TeamId, payload.NewName);
+                await _hubContext.Clients.Group(payload.TeamId.Value.ToString()).SendAsync("ReceiveTeamRenamed", payload.TeamId, payload.NewName);
                 return Ok();
             }
 
@@ -36,8 +36,48 @@ namespace NikoNiko.Notifications.Controllers
                 return BadRequest("User, Message, and UserId cannot be empty.");
             }
 
-            var connectionIdsToExclude = _userConnectionManager.GetConnections(payload.UserId)?.ToArray() ?? new string[0];
-            await _hubContext.Clients.AllExcept(connectionIdsToExclude).SendAsync("ReceiveNotification", payload.User, payload.Message);
+            if (payload.TeamId.HasValue)
+            {
+                // Send to team group, excluding sender
+                var connectionIdsToExclude = _userConnectionManager.GetConnections(payload.UserId)?.ToArray() ?? new string[0];
+                await _hubContext.Clients.GroupExcept(payload.TeamId.Value.ToString(), connectionIdsToExclude).SendAsync("ReceiveNotification", payload.User, payload.Message);
+            }
+            else
+            {
+                // Fallback: Send to all (should likely be avoided in production for privacy, but keeping for legacy compatibility or global announcements)
+                var connectionIdsToExclude = _userConnectionManager.GetConnections(payload.UserId)?.ToArray() ?? new string[0];
+                await _hubContext.Clients.AllExcept(connectionIdsToExclude).SendAsync("ReceiveNotification", payload.User, payload.Message);
+            }
+
+            return Ok();
+        }
+
+        [HttpPost("manage-groups")]
+        public async Task<IActionResult> ManageGroups([FromBody] GroupManagementPayload payload)
+        {
+            if (string.IsNullOrEmpty(payload.UserId) || payload.TeamId == Guid.Empty)
+            {
+                return BadRequest("UserId and TeamId are required.");
+            }
+
+            var connectionIds = _userConnectionManager.GetConnections(payload.UserId);
+            if (connectionIds == null || !connectionIds.Any())
+            {
+                return Ok("User has no active connections.");
+            }
+
+            foreach (var connectionId in connectionIds)
+            {
+                if (payload.Action == "Add")
+                {
+                    await _hubContext.Groups.AddToGroupAsync(connectionId, payload.TeamId.ToString());
+                }
+                else if (payload.Action == "Remove")
+                {
+                    await _hubContext.Groups.RemoveFromGroupAsync(connectionId, payload.TeamId.ToString());
+                }
+            }
+
             return Ok();
         }
     }
@@ -50,5 +90,12 @@ namespace NikoNiko.Notifications.Controllers
         public string? User { get; set; }
         public string? Message { get; set; }
         public string? UserId { get; set; }
+    }
+
+    public class GroupManagementPayload
+    {
+        public string UserId { get; set; } = string.Empty;
+        public Guid TeamId { get; set; }
+        public string Action { get; set; } = "Add"; // "Add" or "Remove"
     }
 }

--- a/api/NikoNiko.Notifications/Hubs/NotificationHub.cs
+++ b/api/NikoNiko.Notifications/Hubs/NotificationHub.cs
@@ -24,6 +24,16 @@ namespace NikoNiko.Notifications.Hubs
             if (userId != null) // Add null check for userId
             {
                 _userConnectionManager.AddConnection(userId, Context.ConnectionId);
+
+                // Join groups for each team the user belongs to
+                var teamIdClaims = Context.User?.FindAll("team_id");
+                if (teamIdClaims != null)
+                {
+                    foreach (var claim in teamIdClaims)
+                    {
+                        await Groups.AddToGroupAsync(Context.ConnectionId, claim.Value);
+                    }
+                }
             }
             await base.OnConnectedAsync();
         }

--- a/api/NikoNiko.Services/INotificationService.cs
+++ b/api/NikoNiko.Services/INotificationService.cs
@@ -4,7 +4,8 @@ namespace NikoNiko.Services
 {
     public interface INotificationService
     {
-        Task SendMoodNotificationAsync(string user, string message, string userId);
+        Task SendMoodNotificationAsync(string user, string message, string userId, Guid teamId);
         Task NotifyTeamRenamedAsync(Guid teamId, string newName);
+        Task UpdateUserGroupAsync(string userId, Guid teamId, bool isJoining);
     }
 }

--- a/api/NikoNiko.Services/NotificationService.cs
+++ b/api/NikoNiko.Services/NotificationService.cs
@@ -18,7 +18,7 @@ namespace NikoNiko.Services
             _logger = logger;
         }
 
-        public async Task SendMoodNotificationAsync(string user, string message, string userId)
+        public async Task SendMoodNotificationAsync(string user, string message, string userId, Guid teamId)
         {
             try
             {
@@ -26,7 +26,8 @@ namespace NikoNiko.Services
                 {
                     User = user,
                     Message = message,
-                    UserId = userId
+                    UserId = userId,
+                    TeamId = teamId
                 };
                 var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
                 var response = await _httpClient.PostAsync("api/notifications/dispatch", content);
@@ -59,6 +60,28 @@ namespace NikoNiko.Services
             catch (HttpRequestException ex)
             {
                 _logger.LogError(ex, "Error sending team renamed notification to SignalR service.");
+            }
+        }
+
+        public async Task UpdateUserGroupAsync(string userId, Guid teamId, bool isJoining)
+        {
+            try
+            {
+                var payload = new
+                {
+                    UserId = userId,
+                    TeamId = teamId,
+                    Action = isJoining ? "Add" : "Remove"
+                };
+                var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync("api/notifications/manage-groups", content);
+
+                response.EnsureSuccessStatusCode();
+                _logger.LogInformation("Group management request ({Action}) sent to SignalR service successfully for user {UserId}.", isJoining ? "Add" : "Remove", userId);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Error sending group management request to SignalR service.");
             }
         }
     }

--- a/api/NikoNiko.Services/TokenService.cs
+++ b/api/NikoNiko.Services/TokenService.cs
@@ -47,6 +47,14 @@ public class TokenService : ITokenService
             claims.Add(new Claim("is_super_admin", "true"));
         }
 
+        if (user.TeamUsers != null)
+        {
+            foreach (var teamUser in user.TeamUsers)
+            {
+                claims.Add(new Claim("team_id", teamUser.TeamId.ToString()));
+            }
+        }
+
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Authentication:Jwt:Key"]!));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature);
 

--- a/plans/20260119-1400--feature_signalr_groups.md
+++ b/plans/20260119-1400--feature_signalr_groups.md
@@ -1,0 +1,112 @@
+# Implementation Plan - Real-time Team Notifications via SignalR Groups
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Implement secure, team-isolated real-time notifications using SignalR Groups. Messages should only be broadcast to members of the specific team where the event occurred.
+*   **Affected Files:**
+    *   `api/NikoNiko.Services/TokenService.cs` (Add team_ids claim)
+    *   `api/NikoNiko.Api/Controllers/AuthController.cs` (Load teams for token)
+    *   `api/NikoNiko.Notifications/Hubs/NotificationHub.cs` (Join groups on connect)
+    *   `api/NikoNiko.Notifications/Controllers/NotificationsController.cs` (Dispatch to groups, manage dynamic membership)
+    *   `api/NikoNiko.Services/NotificationService.cs` & `INotificationService.cs` (Update signatures)
+    *   `api/NikoNiko.Api/Controllers/MoodEntriesController.cs` (Pass teamId)
+    *   `api/NikoNiko.Api/Controllers/TeamInvitationsController.cs` (Trigger group join)
+    *   `api/NikoNiko.Api/Controllers/TeamsController.cs` (Trigger group leave)
+*   **Key Dependencies:** `Microsoft.AspNetCore.SignalR`, `System.Security.Claims`.
+*   **Risks/Unknowns:** Ensuring dynamic group updates work when a user accepts an invitation without requiring a re-login immediately.
+*   **Frontend Impact:** Minimal. The frontend already listens for `ReceiveNotification`. The filtering logic is moved entirely to the server (Group vs All). The client does not need to know which group it is in; it simply receives messages sent to it.
+
+## 2. 📋 Checklist
+- [x] Step 1: Enrich JWT with Team IDs
+- [x] Step 2: Update NotificationHub to Join Groups
+- [x] Step 3: Implement Dynamic Group Management (Immediate Join/Leave)
+- [x] Step 4: Update Notification Service & Controller for Group Broadcasting
+- [x] Step 5: Integrate Mood Entry Notifications
+- [x] Step 6: Integrate Team Invitation & Management Updates
+- [x] Verification
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+5. **No Stealth Actions**: NEVER execute code or modify files without having first updated the plan to reflect that you are about to do so.
+
+### Step 1: Enrich JWT with Team IDs
+*   **Goal:** Include the list of Team IDs the user belongs to in the JWT token so the stateless Notification Hub can read them upon connection/reconnection.
+*   **Status:** [Done]
+*   **Action:**
+    *   Modify `api/NikoNiko.Services/TokenService.cs`:
+        *   Update `CreateToken` to iterate over `user.TeamUsers` and add a `team_id` claim for each team.
+    *   Modify `api/NikoNiko.Api/Controllers/AuthController.cs`:
+        *   Update `HandleSignIn` to `.Include(u => u.TeamUsers)` when fetching the user.
+*   **Verification:** Run `TokenServiceTests` to verify claims are present in the generated token. (Success: 3 tests passed)
+
+### Step 2: Update NotificationHub to Join Groups
+*   **Goal:** Automatically add the user's connection to SignalR groups based on the `team_id` claims in the JWT when they connect.
+*   **Status:** [Done]
+*   **Action:**
+    *   Modify `api/NikoNiko.Notifications/Hubs/NotificationHub.cs`:
+        *   In `OnConnectedAsync`:
+            *   Retrieve all `team_id` claims from `Context.User.Claims`.
+            *   Loop and `await Groups.AddToGroupAsync(Context.ConnectionId, teamId);`.
+*   **Verification:** Manual test: Connect with a token containing team claims and verify logs show group addition.
+
+### Step 3: Implement Dynamic Group Management (Immediate Join/Leave)
+*   **Goal:** Allow backend services to force a user's *active* connections to join/leave a group immediately (e.g., when accepting an invite), addressing the "User Added" scenario without waiting for a token refresh.
+*   **Status:** [Done]
+*   **Action:**
+    *   Modify `api/NikoNiko.Notifications/Controllers/NotificationsController.cs`:
+        *   Add endpoint `POST /manage-groups`. Payload: `{ UserId, TeamId, Action: "Add"|"Remove" }`.
+        *   Use `_userConnectionManager.GetConnections(userId)` to find active connections.
+        *   Call `_hubContext.Groups.AddToGroupAsync` (or Remove) for these connections.
+    *   Modify `api/NikoNiko.Services/INotificationService.cs` & `NotificationService.cs`:
+        *   Add `Task UpdateUserGroupAsync(string userId, Guid teamId, bool isJoining);`
+        *   Implement logic to call the new endpoint.
+*   **Verification:** Unit test `NotificationsController` to ensure `AddToGroupAsync` is called for the user's connections.
+
+### Step 4: Update Notification Service & Controller for Group Broadcasting
+*   **Goal:** Change the broadcasting logic to target specific groups instead of `Clients.All`.
+*   **Status:** [Done]
+*   **Action:**
+    *   Modify `api/NikoNiko.Notifications/Controllers/NotificationsController.cs`:
+        *   Update `Dispatch` to accept `TeamId` in payload.
+        *   Logic: If `TeamId` is present, use `_hubContext.Clients.Group(payload.TeamId.ToString()).SendAsync(...)`.
+        *   Fallback: If no `TeamId`, keep `Clients.All` (or restrict/remove depending on security reqs).
+    *   Modify `api/NikoNiko.Services/INotificationService.cs` & `NotificationService.cs`:
+        *   Update `SendMoodNotificationAsync` to take `Guid teamId`.
+        *   Update payload serialization.
+*   **Verification:** Check compiler errors (breaking change on interface).
+
+### Step 5: Integrate Mood Entry Notifications
+*   **Goal:** Ensure mood entries trigger the group notification.
+*   **Status:** [Done]
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/Controllers/MoodEntriesController.cs`:
+        *   In `CreateMoodEntry`, pass the `teamId` (derived from Sprint) to `SendMoodNotificationAsync`.
+*   **Verification:** Run `MoodEntriesControllerTests`.
+
+### Step 6: Integrate Team Invitation & Management Updates
+*   **Goal:** Ensure joining/leaving teams updates the real-time groups.
+*   **Status:** [Done]
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/Controllers/TeamInvitationsController.cs`:
+        *   In `AcceptTeamInvitation`, after DB success, call `_notificationService.UpdateUserGroupAsync(userId, teamId, true)`.
+    *   Modify `api/NikoNiko.Api/Controllers/TeamsController.cs`:
+        *   In `RemoveUser`, call `_notificationService.UpdateUserGroupAsync(userId, teamId, false)`.
+        *   In `UpdateTeam` (rename), ensure `NotifyTeamRenamedAsync` uses the team group (already passed teamId, just ensure internal wiring is correct).
+*   **Verification:** Manual walkthrough of Invitation flow.
+
+## 4. 🧪 Testing Strategy
+*   **Unit Tests:**
+    *   `TokenServiceTests`: Verify `team_id` claims.
+    *   `NotificationHubTests`: Mock `HubCallerContext` with claims and verify `Groups.Add` is called.
+*   **Integration Tests:**
+    *   `MoodEntriesController`: Mock `INotificationService` and verify `SendMoodNotificationAsync` is called with correct `TeamId`.
+
+## 5. ✅ Success Criteria
+*   When a user posts a mood, ONLY members of that team receive the notification.
+*   A user in Team A and Team B receives notifications for both.
+*   A user NOT in Team A does NOT receive Team A notifications.
+*   Accepting an invitation immediately enables notifications for that team without page refresh.


### PR DESCRIPTION
## Summary
This PR implements team-isolated real-time notifications using SignalR Groups. Previously, notifications were broadcast to all connected clients. This change scopes notifications to specific teams, ensuring privacy and reducing unnecessary network traffic for clients. It includes changes to token generation, SignalR hub management, and notification dispatch logic.

## Key Changes
- **Token Enrichment**: Updated `TokenService` to include `team_id` claims in the JWT for all teams the user belongs to.
- **SignalR Groups**: `NotificationHub` now automatically adds users to SignalR groups corresponding to their `team_id` claims upon connection.
- **Dynamic Group Management**: Added a new `manage-groups` endpoint in `NotificationsController` to allow dynamic addition/removal of users to/from SignalR groups (e.g., when accepting an invitation or being removed from a team) without requiring a reconnection.
- **Targeted Dispatch**: Updated `NotificationService` and `NotificationsController` to dispatch messages to specific team groups via `Clients.Group(...)` instead of `Clients.All`.
- **Integration**:
    - `MoodEntriesController`: Sends mood notifications to the specific team group.
    - `TeamInvitationsController`: Dynamically adds the user to the team's SignalR group upon invitation acceptance.
    - `TeamsController`: Dynamically removes the user from the team's SignalR group upon user removal.
- **Tests**: Added and updated integration tests in `TokenServiceTests`, `MoodEntriesControllerTests`, and `NotificationHubTests` to verify claim generation, notification targeting, and group management.

## Checklist
- [x] Tests passed
- [x] Documentation updated (Technical plan included)

Closes #54