### PR TITLE
feat(profile): User Profile & Privacy Control Center 👤🔒

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerMeTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/MoodEntriesControllerMeTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NikoNiko.Core.DTOs;
+using NikoNiko.Core.DTOs.Mood;
+using NikoNiko.Core.Models;
+using NikoNiko.Data;
+
+using Xunit;
+
+namespace NikoNiko.Api.IntegrationTests;
+
+public class MoodEntriesControllerMeTests
+{
+    [Fact]
+    public async Task GetMyMoodEntries_ShouldReturnPaginatedResults()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Mood History User");
+        
+        // Create a team and sprint to associate moods with
+        Guid sprintId;
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var team = new Team { Id = Guid.NewGuid(), Name = "Team A", AdminId = user.Id };
+            var sprint = new Sprint 
+            { 
+                Id = Guid.NewGuid(), 
+                TeamId = team.Id, 
+                Name = "Sprint 1", 
+                StartDate = DateTime.UtcNow.AddDays(-30), 
+                EndDate = DateTime.UtcNow.AddDays(30) 
+            };
+            
+            dbContext.Teams.Add(team);
+            dbContext.Sprints.Add(sprint);
+            
+            // Create 25 mood entries
+            for (int i = 0; i < 25; i++)
+            {
+                dbContext.MoodEntries.Add(new MoodEntry
+                {
+                    UserId = user.Id,
+                    SprintId = sprint.Id,
+                    Date = DateTime.UtcNow.AddDays(-i),
+                    Mood = MoodType.Happy
+                });
+            }
+            
+            await dbContext.SaveChangesAsync();
+            sprintId = sprint.Id;
+        }
+
+        // Act - Page 1 (Size 10)
+        var responsePage1 = await client.GetAsync("/api/moodentries/me?page=1&pageSize=10");
+        var resultPage1 = await responsePage1.Content.ReadFromJsonAsync<PagedResult<MoodEntryDto>>();
+
+        // Act - Page 2 (Size 10)
+        var responsePage2 = await client.GetAsync("/api/moodentries/me?page=2&pageSize=10");
+        var resultPage2 = await responsePage2.Content.ReadFromJsonAsync<PagedResult<MoodEntryDto>>();
+
+        // Act - Page 3 (Size 10) - Should have 5 items
+        var responsePage3 = await client.GetAsync("/api/moodentries/me?page=3&pageSize=10");
+        var resultPage3 = await responsePage3.Content.ReadFromJsonAsync<PagedResult<MoodEntryDto>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, responsePage1.StatusCode);
+        Assert.NotNull(resultPage1);
+        Assert.Equal(25, resultPage1.TotalCount);
+        Assert.Equal(10, resultPage1.Items.Count());
+        Assert.Equal(1, resultPage1.Page);
+
+        Assert.Equal(HttpStatusCode.OK, responsePage2.StatusCode);
+        Assert.NotNull(resultPage2);
+        Assert.Equal(25, resultPage2.TotalCount);
+        Assert.Equal(10, resultPage2.Items.Count());
+        Assert.Equal(2, resultPage2.Page);
+
+        Assert.Equal(HttpStatusCode.OK, responsePage3.StatusCode);
+        Assert.NotNull(resultPage3);
+        Assert.Equal(25, resultPage3.TotalCount);
+        Assert.Equal(5, resultPage3.Items.Count());
+        Assert.Equal(3, resultPage3.Page);
+    }
+}

--- a/api/NikoNiko.Api.IntegrationTests/UsersControllerDeleteMeTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/UsersControllerDeleteMeTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NikoNiko.Core.Models;
+using NikoNiko.Data;
+
+using Xunit;
+
+namespace NikoNiko.Api.IntegrationTests;
+
+public class UsersControllerDeleteMeTests
+{
+    [Fact]
+    public async Task DeleteMe_ShouldDeleteCurrentUser()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Self Deletor");
+
+        // Act
+        var response = await client.DeleteAsync("/api/users/me");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var dbUser = await dbContext.Users.FindAsync(user.Id);
+            Assert.Null(dbUser);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteMe_WhenAdminOfTeamWithOtherMembers_ShouldReturnConflict()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Admin User");
+        var (otherUser, _, _) = await application.CreateUserAndClient("Other Member");
+
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var team = new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = "Shared Team",
+                AdminId = user.Id
+            };
+
+            dbContext.Teams.Add(team);
+            dbContext.TeamUsers.Add(new TeamUser { TeamId = team.Id, UserId = user.Id });
+            dbContext.TeamUsers.Add(new TeamUser { TeamId = team.Id, UserId = otherUser.Id });
+            await dbContext.SaveChangesAsync();
+        }
+
+        // Act
+        var response = await client.DeleteAsync("/api/users/me");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteMe_WhenAdminOfTeamWithNoOtherMembers_ShouldDeleteUserAndTeam()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Sole Admin");
+        Guid teamId;
+
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var team = new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = "Sole Team",
+                AdminId = user.Id
+            };
+            dbContext.Teams.Add(team);
+            dbContext.TeamUsers.Add(new TeamUser { TeamId = team.Id, UserId = user.Id });
+            await dbContext.SaveChangesAsync();
+            teamId = team.Id;
+        }
+
+        // Act
+        var response = await client.DeleteAsync("/api/users/me");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var dbUser = await dbContext.Users.FindAsync(user.Id);
+            var dbTeam = await dbContext.Teams.FindAsync(teamId);
+            Assert.Null(dbUser);
+            Assert.Null(dbTeam);
+        }
+    }
+}

--- a/api/NikoNiko.Api/Controllers/MoodEntriesController.cs
+++ b/api/NikoNiko.Api/Controllers/MoodEntriesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
+using NikoNiko.Core.DTOs;
 using NikoNiko.Core.DTOs.Mood;
 using NikoNiko.Core.Models;
 using NikoNiko.Data;
@@ -81,6 +82,57 @@ public class MoodEntriesController : ControllerBase
             .ToListAsync();
 
         return Ok(moodEntries);
+    }
+
+    /// <summary>
+    /// Gets the current user's mood history with pagination.
+    /// </summary>
+    /// <param name="page">The page number (1-based).</param>
+    /// <param name="pageSize">The number of items per page.</param>
+    /// <returns>A paged result of MoodEntryDto objects.</returns>
+    [HttpGet("me")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<PagedResult<MoodEntryDto>>> GetMyMoodEntries([FromQuery] int page = 1, [FromQuery] int pageSize = 20)
+    {
+        var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdString, out var userId))
+        {
+            return Unauthorized("User ID not found or invalid.");
+        }
+
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 20;
+        if (pageSize > 100) pageSize = 100; // Cap page size
+
+        var query = _context.MoodEntries
+            .Where(me => me.UserId == userId);
+
+        var totalCount = await query.CountAsync();
+
+        var moodEntries = await query
+            .OrderByDescending(me => me.Date)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(me => new MoodEntryDto
+            {
+                Id = me.Id,
+                UserId = me.UserId,
+                SprintId = me.SprintId,
+                Date = me.Date.ToUniversalTime(),
+                Mood = me.Mood
+            })
+            .ToListAsync();
+
+        var result = new PagedResult<MoodEntryDto>
+        {
+            Items = moodEntries,
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize
+        };
+
+        return Ok(result);
     }
 
     /// <summary>

--- a/api/NikoNiko.Api/Controllers/UsersController.cs
+++ b/api/NikoNiko.Api/Controllers/UsersController.cs
@@ -146,6 +146,56 @@ public class UsersController : ControllerBase
     }
 
     /// <summary>
+    /// Deletes the current user's account.
+    /// </summary>
+    /// <returns>NoContent if successful, or an error response.</returns>
+    [HttpDelete("me")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> DeleteMe()
+    {
+        var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdString, out var userId))
+        {
+            return Unauthorized();
+        }
+
+        var user = await _context.Users.FindAsync(userId);
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        // Check if user is admin of any teams
+        var teamsAsAdmin = await _context.Teams
+            .Include(t => t.TeamUsers)
+            .Where(t => t.AdminId == userId)
+            .ToListAsync();
+
+        if (teamsAsAdmin.Any())
+        {
+            foreach (var team in teamsAsAdmin)
+            {
+                var otherMembersCount = team.TeamUsers.Count(tu => tu.UserId != userId);
+
+                if (otherMembersCount > 0)
+                {
+                    return Conflict($"Cannot delete your account because you are the admin of team '{team.Name}' which has other members. Please transfer ownership or remove members first.");
+                }
+
+                _context.Teams.Remove(team);
+            }
+        }
+
+        _context.Users.Remove(user);
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    /// <summary>
     /// Deletes a specific user account. Accessible only by super-admins.
     /// A user cannot delete their own account.
     /// </summary>

--- a/api/NikoNiko.Core/DTOs/PagedResult.cs
+++ b/api/NikoNiko.Core/DTOs/PagedResult.cs
@@ -1,0 +1,10 @@
+namespace NikoNiko.Core.DTOs;
+
+public class PagedResult<T>
+{
+    public IEnumerable<T> Items { get; set; } = new List<T>();
+    public int TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+}

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 // notistack imports
 import { SnackbarProvider } from 'notistack';
 
@@ -28,11 +29,14 @@ import DashboardPage from '@/pages/DashboardPage';
 import LoginPage from '@/pages/LoginPage';
 import OnboardingPage from '@/pages/OnboardingPage';
 import PastSprintsPage from '@/pages/PastSprintsPage';
+import ProfilePage from '@/pages/ProfilePage';
 import SprintDetailsPage from '@/pages/SprintDetailsPage';
 
 import './App.css';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/en';
+
+dayjs.extend(localizedFormat);
 
 const ProtectedLayout = () => (
   <ProtectedRoute>
@@ -89,6 +93,7 @@ function App() {
 
               {/* User Dashboard */}
               <Route path="/my-teams" element={<DashboardPage />} />
+              <Route path="/profile" element={<ProfilePage />} />
               <Route path="/teams/:teamId/sprints/:sprintId" element={<SprintDetailsPage />} />
               <Route path="/current-sprints" element={<CurrentSprintsPage />} />
               <Route path="/past-sprints" element={<PastSprintsPage />} />

--- a/app/frontend/src/components/layout/Sidebar.tsx
+++ b/app/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useNavigate } from 'react-router-dom';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import BugReportIcon from '@mui/icons-material/BugReport';
@@ -398,6 +399,12 @@ const Sidebar: React.FC<SidebarProps> = ({ open, handleDrawerClose, handleDrawer
               },
             }}
           >
+            <MenuItem onClick={() => navigate('/profile')}>
+              <ListItemIcon>
+                <AccountCircleIcon fontSize="small" />
+              </ListItemIcon>
+              {t('sidebar.profile')}
+            </MenuItem>
             {repoUrl && (
               <MenuItem component="a" href={repoUrl} target="_blank" rel="noopener noreferrer">
                 <ListItemIcon>

--- a/app/frontend/src/i18n/locales/en.json
+++ b/app/frontend/src/i18n/locales/en.json
@@ -28,6 +28,7 @@
     "teams": "Teams",
     "users": "Users",
     "sprints": "Sprints",
+    "profile": "My Profile",
     "login": "Login",
     "reportBug": "Report a Bug",
     "mode": "{{mode}} Mode"
@@ -186,6 +187,31 @@
       "errorFill": "Please fill in all fields and select a team.",
       "errorDate": "End date must be after start date.",
       "errorFail": "Failed to create sprint. Please try again."
+    }
+  },
+  "profile": {
+    "title": "My Profile",
+    "tabs": {
+      "general": "General & Privacy",
+      "moodHistory": "Mood History"
+    },
+    "general": {
+      "accountInfo": "Account Information",
+      "privacyZone": "Privacy & Data",
+      "exportData": "Export My Data",
+      "exportTooltip": "Feature coming soon",
+      "deleteAccount": "Delete My Account",
+      "deleteWarning": "Danger Zone: This action is irreversible."
+    },
+    "deleteDialog": {
+      "title": "Delete Your Account?",
+      "content": "Are you sure you want to delete your account? All your personal data will be permanently removed. If you are the sole admin of a team with other members, you must transfer ownership first.",
+      "confirm": "Yes, Delete My Account",
+      "success": "Account deleted successfully.",
+      "error": "Failed to delete account."
+    },
+    "history": {
+      "noData": "No mood history found."
     }
   }
 }

--- a/app/frontend/src/i18n/locales/fr.json
+++ b/app/frontend/src/i18n/locales/fr.json
@@ -28,6 +28,7 @@
     "teams": "Équipes",
     "users": "Utilisateurs",
     "sprints": "Sprints",
+    "profile": "Mon Profil",
     "login": "Connexion",
     "reportBug": "Signaler un bug",
     "mode": "Mode {{mode}}"
@@ -186,6 +187,31 @@
       "errorFill": "Veuillez remplir tous les champs et sélectionner une équipe.",
       "errorDate": "La date de fin doit être postérieure à la date de début.",
       "errorFail": "Échec de la création du sprint. Veuillez réessayer."
+    }
+  },
+  "profile": {
+    "title": "Mon Profil",
+    "tabs": {
+      "general": "Général & Confidentialité",
+      "moodHistory": "Historique d'Humeur"
+    },
+    "general": {
+      "accountInfo": "Informations du Compte",
+      "privacyZone": "Confidentialité & Données",
+      "exportData": "Exporter mes données",
+      "exportTooltip": "Fonctionnalité à venir",
+      "deleteAccount": "Supprimer mon compte",
+      "deleteWarning": "Zone de danger : Cette action est irréversible."
+    },
+    "deleteDialog": {
+      "title": "Supprimer votre compte ?",
+      "content": "Êtes-vous sûr de vouloir supprimer votre compte ? Toutes vos données personnelles seront définitivement supprimées. Si vous êtes le seul administrateur d'une équipe avec d'autres membres, vous devez d'abord transférer la propriété.",
+      "confirm": "Oui, supprimer mon compte",
+      "success": "Compte supprimé avec succès.",
+      "error": "Échec de la suppression du compte."
+    },
+    "history": {
+      "noData": "Aucun historique d'humeur trouvé."
     }
   }
 }

--- a/app/frontend/src/models/PagedResult.ts
+++ b/app/frontend/src/models/PagedResult.ts
@@ -1,0 +1,7 @@
+export interface PagedResult<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}

--- a/app/frontend/src/pages/ProfilePage.tsx
+++ b/app/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,329 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import DeleteIcon from '@mui/icons-material/Delete';
+import DownloadIcon from '@mui/icons-material/Download';
+import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
+import SentimentSatisfiedIcon from '@mui/icons-material/SentimentSatisfied';
+import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt';
+import {
+  Avatar,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Paper,
+  Tab,
+  TablePagination,
+  Tabs,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import { useSnackbar } from 'notistack';
+import useSWR from 'swr';
+
+import { useAuth } from '@/context/AuthContext';
+import { MoodValues } from '@/models/MoodType';
+import { getMyMoodHistory } from '@/services/moodService';
+import { deleteMe, getUser } from '@/services/userService';
+
+import PageContainer from '@/components/layout/PageContainer';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+const ProfilePage = () => {
+  const { t } = useTranslation();
+  const { user, logout } = useAuth();
+  const { enqueueSnackbar } = useSnackbar();
+  const navigate = useNavigate();
+  const [value, setValue] = useState(0);
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+
+  // Pagination state
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+
+  const {
+    data: historyData,
+    isLoading,
+    error: historyError,
+  } = useSWR(user ? ['/moodentries/me', page, pageSize] : null, () =>
+    getMyMoodHistory(page + 1, pageSize),
+  );
+
+  const { data: userDetails } = useSWR(user ? `/users/${user.sub}` : null, () =>
+    getUser(user!.sub),
+  );
+
+  const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangePageSize = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPageSize(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const handleDeleteAccount = async () => {
+    try {
+      await deleteMe();
+      enqueueSnackbar(t('profile.deleteDialog.success'), { variant: 'success' });
+      logout();
+      navigate('/login');
+    } catch (error) {
+      console.error('Failed to delete account:', error);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const errorMessage = (error as any).response?.data || t('profile.deleteDialog.error');
+      enqueueSnackbar(errorMessage, { variant: 'error' });
+      setOpenDeleteDialog(false);
+    }
+  };
+
+  const getMoodIcon = (moodType: number) => {
+    switch (moodType) {
+      case MoodValues.Happy:
+        return <SentimentSatisfiedAltIcon color="success" />;
+      case MoodValues.Neutral:
+        return <SentimentSatisfiedIcon color="info" />;
+      case MoodValues.Sad:
+        return <SentimentDissatisfiedIcon color="error" />;
+      default:
+        return null;
+    }
+  };
+
+  const getMoodLabel = (moodType: number) => {
+    switch (moodType) {
+      case MoodValues.Happy:
+        return t('mood.happy');
+      case MoodValues.Neutral:
+        return t('mood.neutral');
+      case MoodValues.Sad:
+        return t('mood.sad');
+      default:
+        return '';
+    }
+  };
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <PageContainer title={t('profile.title')} icon={<AccountCircleIcon />}>
+      <Paper sx={{ width: '100%' }}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Tabs value={value} onChange={handleChange} aria-label="profile tabs">
+            <Tab label={t('profile.tabs.general')} {...a11yProps(0)} />
+            <Tab label={t('profile.tabs.moodHistory')} {...a11yProps(1)} />
+          </Tabs>
+        </Box>
+        <CustomTabPanel value={value} index={0}>
+          <Grid container spacing={4}>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Typography variant="h6" gutterBottom>
+                {t('profile.general.accountInfo')}
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
+                <Avatar
+                  src={user.avatar_url}
+                  alt={user.name}
+                  sx={{ width: 80, height: 80, mr: 2 }}
+                />
+                <Box>
+                  <Typography variant="h6">{user.name}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {userDetails?.provider || '...'}
+                  </Typography>
+                </Box>
+              </Box>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  label={t('adminUsers.table.name')}
+                  value={user.name}
+                  slotProps={{
+                    input: {
+                      readOnly: true,
+                    },
+                  }}
+                  fullWidth
+                />
+                <TextField
+                  label={t('adminUsers.table.email')}
+                  value={user.email || ''}
+                  slotProps={{
+                    input: {
+                      readOnly: true,
+                    },
+                  }}
+                  fullWidth
+                />
+                <TextField
+                  label={t('adminUsers.table.createdAt')}
+                  value={
+                    userDetails?.createdAt
+                      ? dayjs(userDetails.createdAt).format('L')
+                      : '...'
+                  }
+                  slotProps={{
+                    input: {
+                      readOnly: true,
+                    },
+                  }}
+                  fullWidth
+                />
+              </Box>
+            </Grid>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Typography variant="h6" gutterBottom color="error">
+                {t('profile.general.privacyZone')}
+              </Typography>
+              <Divider sx={{ mb: 3 }} />
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Box>
+                  <Typography variant="subtitle1" gutterBottom>
+                    {t('profile.general.exportData')}
+                  </Typography>
+                  <Tooltip title={t('profile.general.exportTooltip')}>
+                    <span>
+                      <Button
+                        variant="outlined"
+                        startIcon={<DownloadIcon />}
+                        disabled
+                        fullWidth
+                        sx={{ justifyContent: 'flex-start' }}
+                      >
+                        {t('profile.general.exportData')}
+                      </Button>
+                    </span>
+                  </Tooltip>
+                </Box>
+
+                <Box sx={{ mt: 2 }}>
+                  <Typography variant="subtitle1" color="error" gutterBottom>
+                    {t('profile.general.deleteAccount')}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" paragraph>
+                    {t('profile.general.deleteWarning')}
+                  </Typography>
+                  <Button
+                    variant="contained"
+                    color="error"
+                    startIcon={<DeleteIcon />}
+                    onClick={() => setOpenDeleteDialog(true)}
+                    fullWidth
+                    sx={{ justifyContent: 'flex-start' }}
+                  >
+                    {t('profile.general.deleteAccount')}
+                  </Button>
+                </Box>
+              </Box>
+            </Grid>
+          </Grid>
+        </CustomTabPanel>
+        <CustomTabPanel value={value} index={1}>
+          {isLoading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+              <CircularProgress />
+            </Box>
+          ) : historyError ? (
+            <Typography color="error">{t('common.error')}</Typography>
+          ) : historyData && historyData.items.length > 0 ? (
+            <>
+              <List>
+                {historyData.items.map((entry) => (
+                  <ListItem key={entry.id} divider>
+                    <ListItemIcon>{getMoodIcon(entry.mood)}</ListItemIcon>
+                    <ListItemText
+                      primary={getMoodLabel(entry.mood)}
+                      secondary={dayjs(entry.date).format('dddd, D MMMM YYYY')}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+              <TablePagination
+                component="div"
+                count={historyData.totalCount}
+                page={page}
+                onPageChange={handleChangePage}
+                rowsPerPage={pageSize}
+                onRowsPerPageChange={handleChangePageSize}
+                rowsPerPageOptions={[5, 10, 25, 50]}
+              />
+            </>
+          ) : (
+            <Typography sx={{ p: 2, textAlign: 'center', color: 'text.secondary' }}>
+              {t('profile.history.noData')}
+            </Typography>
+          )}
+        </CustomTabPanel>
+      </Paper>
+
+      <Dialog
+        open={openDeleteDialog}
+        onClose={() => setOpenDeleteDialog(false)}
+        aria-labelledby="delete-dialog-title"
+        aria-describedby="delete-dialog-description"
+      >
+        <DialogTitle id="delete-dialog-title">{t('profile.deleteDialog.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="delete-dialog-description">
+            {t('profile.deleteDialog.content')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDeleteDialog(false)}>{t('common.cancel')}</Button>
+          <Button onClick={handleDeleteAccount} color="error" autoFocus>
+            {t('profile.deleteDialog.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </PageContainer>
+  );
+};
+
+export default ProfilePage;

--- a/app/frontend/src/services/moodService.ts
+++ b/app/frontend/src/services/moodService.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import type { CreateMood } from '@/models/CreateMood';
 import type { Mood } from '@/models/Mood';
+import type { PagedResult } from '@/models/PagedResult';
 
 import api from './api';
 
@@ -37,5 +38,10 @@ export const getMoodEntriesBySprint = async (
     url += `?${params.toString()}`;
   }
   const { data } = await api.get(url);
+  return data;
+};
+
+export const getMyMoodHistory = async (page = 1, pageSize = 20): Promise<PagedResult<Mood>> => {
+  const { data } = await api.get(`/moodentries/me?page=${page}&pageSize=${pageSize}`);
   return data;
 };

--- a/app/frontend/src/services/userService.ts
+++ b/app/frontend/src/services/userService.ts
@@ -7,6 +7,15 @@ export const getUsers = async (): Promise<User[]> => {
   return data;
 };
 
+export const getUser = async (userId: string): Promise<User> => {
+  const { data } = await api.get(`/users/${userId}`);
+  return data;
+};
+
 export const deleteUser = async (userId: string): Promise<void> => {
   await api.delete(`/users/${userId}`);
+};
+
+export const deleteMe = async (): Promise<void> => {
+  await api.delete('/users/me');
 };

--- a/plans/20260120-1000--feature_user_profile.md
+++ b/plans/20260120-1000--feature_user_profile.md
@@ -1,0 +1,107 @@
+# Implementation Plan - Feature User Profile & Privacy Control Center
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Create a dedicated user profile page to manage personal information, delete account (GDPR), and view private mood history with pagination.
+*   **Affected Files:**
+    *   `api/NikoNiko.Api/Controllers/UsersController.cs`
+    *   `api/NikoNiko.Api/Controllers/MoodEntriesController.cs`
+    *   `app/frontend/src/App.tsx`
+    *   `app/frontend/src/services/users.ts`
+    *   `app/frontend/src/services/moods.ts`
+    *   `app/frontend/src/pages/ProfilePage.tsx` (New)
+*   **Key Dependencies:** `MUI` (Tabs, Pagination), `swr`, `axios`, `React Router`.
+*   **Risks/Unknowns:**
+    *   **Self-Deletion:** Must ensure orphaned teams are handled.
+    *   **Pagination:** Need a standard PagedResult structure in API.
+
+## 2. 📋 Checklist
+- [x] Step 1: Backend - Implement `DELETE /api/users/me`
+- [x] Step 2: Backend - Implement `GET /api/mood-entries/me` (Paginated)
+- [x] Step 3: Frontend - Add API Services & Route
+- [x] Step 4: Frontend - Create Profile Page Structure (Tabs)
+- [x] Step 5: Frontend - Implement General Info & Delete Logic (Export Disabled)
+- [x] Step 6: Frontend - Implement Mood History Tab (Paginated)
+- [x] Verification
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+5. **No Stealth Actions**: NEVER execute code or modify files without having first updated the plan to reflect that you are about to do so.
+
+### Step 1: Backend - Implement `DELETE /api/users/me`
+*   **Goal:** Allow a user to delete their own account.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/Controllers/UsersController.cs`:
+        *   Add `[HttpDelete("me")]`.
+        *   Logic: Get `userId` from claims. Validate (check if admin of team with other members). Delete user.
+*   **Verification:** Swagger test `DELETE /api/users/me`.
+
+### Step 2: Backend - Implement `GET /api/mood-entries/me` (Paginated)
+*   **Goal:** Efficiently fetch the current user's mood history with pagination.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/Controllers/MoodEntriesController.cs`:
+        *   Add `[HttpGet("me")]` with parameters `[FromQuery] int page = 1`, `[FromQuery] int pageSize = 20`.
+        *   Logic: `_context.MoodEntries.Where(m => m.UserId == currentUserId).OrderByDescending(m => m.Date)`.
+        *   Return: `{ items: IEnumerable<MoodEntryDto>, totalCount: int, page: int, pageSize: int }`.
+*   **Verification:** Swagger test `GET /api/mood-entries/me?page=1&pageSize=5`.
+
+### Step 3: Frontend - Add API Services & Route
+*   **Goal:** Prepare frontend plumbing.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `app/frontend/src/services/users.ts`: Add `deleteMe()`.
+    *   Modify `app/frontend/src/services/moods.ts`: Add `getMyMoodHistory(page, pageSize)`.
+    *   Modify `app/frontend/src/App.tsx`: Add Route `/profile` -> `ProfilePage`.
+    *   Create `app/frontend/src/pages/ProfilePage.tsx` (Skeleton).
+*   **Verification:** App compiles, navigating to `/profile` shows skeleton.
+
+### Step 4: Frontend - Create Profile Page Structure (Tabs)
+*   **Goal:** Layout with Tabs.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `app/frontend/src/pages/ProfilePage.tsx`:
+        *   Use MUI `Tabs`: "Profile", "Data & Privacy", "Mood History".
+*   **Verification:** Visual check of tabs.
+
+### Step 5: Frontend - Implement General Info & Delete Logic
+*   **Goal:** Show user info and allow dangerous actions. Export is disabled.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `app/frontend/src/pages/ProfilePage.tsx`:
+        *   "Profile": Avatar, Name, Email, Provider.
+        *   "Data & Privacy":
+            *   Button "Export Data" -> **Disabled** (Tooltip: "Coming soon").
+            *   Button "Delete Account" (Red) -> Confirmation Dialog -> calls `deleteMe` -> Logout.
+*   **Verification:** Check Export button is disabled. Test Delete (with mock/test account).
+
+### Step 6: Frontend - Implement Mood History Tab (Paginated)
+*   **Goal:** Visualize history with pagination.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `app/frontend/src/pages/ProfilePage.tsx`:
+        *   "Mood History": Fetch `getMyMoodHistory`.
+        *   Render list/table.
+        *   Add MUI `TablePagination` or similar control to change page/pageSize.
+*   **Verification:** Verify pagination controls load new data.
+
+## 4. 🧪 Testing Strategy
+*   **Unit Tests:**
+    *   `UsersControllerTests`: Test `DeleteMe` constraints.
+    *   `MoodEntriesControllerTests`: Test Pagination logic (page 1 vs page 2).
+*   **Manual Verification:**
+    *   Go to `/profile`.
+    *   Check "Export" is disabled.
+    *   Check Mood History pagination (create > 20 moods if needed).
+    *   Delete Account.
+
+## 5. ✅ Success Criteria
+*   User can navigate to `/profile`.
+*   "Export Data" button is visible but disabled.
+*   User can delete their account (GDPR).
+*   User can view their mood history with pagination.


### PR DESCRIPTION
## Summary
This PR implements the User Profile and Privacy Control Center (Issue #57), enabling users to view their account details, access their mood history, and permanently delete their account. This ensures compliance with privacy requirements and enhances user agency within the application.

## Key Changes

### 🟢 Backend (.NET)
- **New Endpoint (`DELETE /api/users/me`)**: Allows users to delete their own account. Includes validation to prevent deletion if the user is the sole admin of a team.
- **New Endpoint (`GET /api/mood-entries/me`)**: Returns a paginated list of the authenticated user's mood history.
- **DTOs**: Introduced `PagedResult<T>` in `NikoNiko.Core` for standardized pagination responses.
- **Tests**: Added comprehensive integration tests (`UsersControllerDeleteMeTests`, `MoodEntriesControllerMeTests`).

### 🔵 Frontend (React)
- **New Page (`/profile`)**: Created a standardized page with a tabbed interface:
    - **General**: Displays user profile information (Avatar, Name, Email, Provider, Registration Date) and a "Danger Zone" for account deletion.
    - **Mood History**: Displays a paginated list of past mood entries.
- **Date Formatting**: Integrated `dayjs` with the `localizedFormat` plugin to handle locale-aware date display (e.g., `createdAt`, mood dates).
- **Navigation**: Updated `Sidebar` and `App.tsx` router to include the new Profile route.
- **Services**: Updated `userService` and `moodService` to consume the new endpoints.

## Checklist
- [x] Tests passed (All 49 integration tests passed)
- [x] Frontend Build & Lint passed
- [x] Documentation updated (Swagger/OpenAPI auto-generated)
- [x] Translations added (EN/FR)


Closes #57