### PR TITLE
feat(users): implement personal data portability and export 💾

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/UsersControllerExportTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/UsersControllerExportTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using NikoNiko.Core.DTOs.User.Export;
+using NikoNiko.Core.Models;
+using NikoNiko.Data;
+using NikoNiko.Services;
+
+namespace NikoNiko.Api.IntegrationTests;
+
+public class UsersControllerExportTests : IClassFixture<NikoNikoApiTestApplication>
+{
+    private readonly NikoNikoApiTestApplication _factory;
+
+    public UsersControllerExportTests(NikoNikoApiTestApplication factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ExportData_ShouldReturnJsonFile_WithCorrectData()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // 1. Create a user
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var tokenService = scope.ServiceProvider.GetRequiredService<ITokenService>();
+
+        var user = new User
+        {
+            OAuthId = "export-test-oauth",
+            Name = "Export Tester",
+            Email = "export@test.com",
+            Provider = "GitHub",
+            CreatedAt = DateTime.UtcNow
+        };
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        // 2. Create a team and add user
+        var team = new Team
+        {
+            Name = "Export Team",
+            AdminId = user.Id
+        };
+        dbContext.Teams.Add(team);
+        await dbContext.SaveChangesAsync();
+
+        dbContext.TeamUsers.Add(new TeamUser { UserId = user.Id, TeamId = team.Id });
+        await dbContext.SaveChangesAsync();
+
+        // 3. Create a sprint and mood entry
+        var sprint = new Sprint
+        {
+            Name = "Sprint Export",
+            StartDate = DateTime.UtcNow.AddDays(-5),
+            EndDate = DateTime.UtcNow.AddDays(5),
+            TeamId = team.Id
+        };
+        dbContext.Sprints.Add(sprint);
+        await dbContext.SaveChangesAsync();
+
+        var moodEntry = new MoodEntry
+        {
+            UserId = user.Id,
+            SprintId = sprint.Id,
+            Mood = MoodType.Happy,
+            Date = DateTime.UtcNow.AddDays(-1)
+        };
+        dbContext.MoodEntries.Add(moodEntry);
+        await dbContext.SaveChangesAsync();
+
+        // Generate Token
+        var token = tokenService.CreateToken(user);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await client.GetAsync("/api/users/me/export");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var exportDto = JsonSerializer.Deserialize<UserExportDto>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(exportDto);
+        
+        // Identity Check
+        Assert.Equal(user.Name, exportDto.Identity.Username);
+        
+        // Team Check
+        Assert.Single(exportDto.Teams);
+        var exportedTeam = exportDto.Teams.First();
+        Assert.Equal(team.Name, exportedTeam.Name);
+        Assert.NotEqual(team.Id.ToString(), exportedTeam.Id); // ID should be hashed
+        
+        // Mood Check
+        Assert.Single(exportDto.History);
+        var exportedMood = exportDto.History.First();
+        Assert.Equal(MoodType.Happy.ToString(), exportedMood.Mood);
+        Assert.Equal(exportedTeam.Id, exportedMood.TeamId); // Team IDs should match between sections
+    }
+}

--- a/api/NikoNiko.Api/Controllers/UsersController.cs
+++ b/api/NikoNiko.Api/Controllers/UsersController.cs
@@ -20,11 +20,13 @@ public class UsersController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
     private readonly ITokenService _tokenService;
+    private readonly IUserService _userService;
 
-    public UsersController(ApplicationDbContext context, ITokenService tokenService)
+    public UsersController(ApplicationDbContext context, ITokenService tokenService, IUserService userService)
     {
         _context = context;
         _tokenService = tokenService;
+        _userService = userService;
     }
 
     /// <summary>
@@ -63,6 +65,33 @@ public class UsersController : ControllerBase
         var newToken = _tokenService.CreateToken(user);
 
         return Ok(new { token = newToken });
+    }
+
+    /// <summary>
+    /// Exports the current user's data (Profile, Teams, Mood History) in JSON format.
+    /// </summary>
+    /// <returns>A JSON file download.</returns>
+    [HttpGet("me/export")]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ExportData()
+    {
+        var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdString, out var userId))
+        {
+            return Unauthorized();
+        }
+
+        var exportDto = await _userService.GetExportDataAsync(userId);
+        if (exportDto == null)
+        {
+            return NotFound();
+        }
+
+        var jsonBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(exportDto, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        var fileName = $"nikoniko-export-{DateTime.UtcNow:yyyyMMdd}.json";
+
+        return File(jsonBytes, "application/json", fileName);
     }
 
     /// <summary>

--- a/api/NikoNiko.Api/Program.cs
+++ b/api/NikoNiko.Api/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddControllers();
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<ITeamInvitationService, TeamInvitationService>();
 builder.Services.AddScoped<ITeamService, TeamService>();
+builder.Services.AddScoped<IUserService, UserService>();
 
 // Add HttpContextAccessor
 builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/api/NikoNiko.Core/DTOs/User/Export/UserExportDto.cs
+++ b/api/NikoNiko.Core/DTOs/User/Export/UserExportDto.cs
@@ -1,0 +1,30 @@
+namespace NikoNiko.Core.DTOs.User.Export;
+
+public class UserExportDto
+{
+    public IdentityExportDto Identity { get; set; } = new();
+    public List<TeamExportDto> Teams { get; set; } = new();
+    public List<MoodExportDto> History { get; set; } = new();
+}
+
+public class IdentityExportDto
+{
+    public string OpenId { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string? Provider { get; set; }
+    public DateTime JoinedAt { get; set; }
+}
+
+public class TeamExportDto
+{
+    public string Id { get; set; } = string.Empty; // Normalized ID
+    public string Name { get; set; } = string.Empty;
+    public int MemberCount { get; set; }
+}
+
+public class MoodExportDto
+{
+    public DateTime Date { get; set; }
+    public string Mood { get; set; } = string.Empty;
+    public string TeamId { get; set; } = string.Empty; // Normalized ID reference
+}

--- a/api/NikoNiko.Services/IUserService.cs
+++ b/api/NikoNiko.Services/IUserService.cs
@@ -1,0 +1,8 @@
+using NikoNiko.Core.DTOs.User.Export;
+
+namespace NikoNiko.Services;
+
+public interface IUserService
+{
+    Task<UserExportDto?> GetExportDataAsync(Guid userId);
+}

--- a/api/NikoNiko.Services/UserService.cs
+++ b/api/NikoNiko.Services/UserService.cs
@@ -1,0 +1,87 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using NikoNiko.Core.DTOs.User.Export;
+using NikoNiko.Data;
+
+namespace NikoNiko.Services;
+
+public class UserService : IUserService
+{
+    private readonly ApplicationDbContext _context;
+
+    public UserService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<UserExportDto?> GetExportDataAsync(Guid userId)
+    {
+        var user = await _context.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == userId);
+
+        if (user == null)
+        {
+            return null;
+        }
+
+        // 1. Fetch Teams (Id, Name, MemberCount)
+        var teamsData = await _context.Teams
+            .AsNoTracking()
+            .Where(t => t.TeamUsers.Any(tu => tu.UserId == userId))
+            .Select(t => new
+            {
+                t.Id,
+                t.Name,
+                MemberCount = t.TeamUsers.Count
+            })
+            .ToListAsync();
+
+        // 2. Fetch Mood History
+        var moodHistory = await _context.MoodEntries
+            .AsNoTracking()
+            .Include(m => m.Sprint)
+            .Where(m => m.UserId == userId)
+            .OrderByDescending(m => m.Date)
+            .Select(m => new
+            {
+                m.Date,
+                m.Mood,
+                TeamId = m.Sprint.TeamId
+            })
+            .ToListAsync();
+
+        // 3. Assemble DTO
+        return new UserExportDto
+        {
+            Identity = new IdentityExportDto
+            {
+                OpenId = user.OAuthId,
+                Username = user.Name,
+                Provider = user.Provider,
+                JoinedAt = user.CreatedAt
+            },
+            Teams = teamsData.Select(t => new TeamExportDto
+            {
+                Id = NormalizeId(t.Id),
+                Name = t.Name,
+                MemberCount = t.MemberCount
+            }).ToList(),
+            History = moodHistory.Select(m => new MoodExportDto
+            {
+                Date = m.Date,
+                Mood = m.Mood.ToString(),
+                TeamId = NormalizeId(m.TeamId)
+            }).ToList()
+        };
+    }
+
+    private static string NormalizeId(Guid id)
+    {
+        using var sha256 = SHA256.Create();
+        var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(id.ToString()));
+        // Take first 8 bytes and convert to hex to keep it short but stable
+        return BitConverter.ToString(hashBytes, 0, 8).Replace("-", "").ToLowerInvariant();
+    }
+}

--- a/app/frontend/src/pages/ProfilePage.tsx
+++ b/app/frontend/src/pages/ProfilePage.tsx
@@ -38,7 +38,7 @@ import useSWR from 'swr';
 import { useAuth } from '@/context/AuthContext';
 import { MoodValues } from '@/models/MoodType';
 import { getMyMoodHistory } from '@/services/moodService';
-import { deleteMe, getUser } from '@/services/userService';
+import { deleteMe, exportData, getUser } from '@/services/userService';
 
 import PageContainer from '@/components/layout/PageContainer';
 
@@ -78,6 +78,7 @@ const ProfilePage = () => {
   const navigate = useNavigate();
   const [value, setValue] = useState(0);
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
 
   // Pagination state
   const [page, setPage] = useState(0);
@@ -120,6 +121,26 @@ const ProfilePage = () => {
       const errorMessage = (error as any).response?.data || t('profile.deleteDialog.error');
       enqueueSnackbar(errorMessage, { variant: 'error' });
       setOpenDeleteDialog(false);
+    }
+  };
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const blob = await exportData();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `nikoniko-export-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Export failed', error);
+      enqueueSnackbar(t('common.error'), { variant: 'error' });
+    } finally {
+      setIsExporting(false);
     }
   };
 
@@ -232,12 +253,13 @@ const ProfilePage = () => {
                     <span>
                       <Button
                         variant="outlined"
-                        startIcon={<DownloadIcon />}
-                        disabled
+                        startIcon={isExporting ? <CircularProgress size={20} /> : <DownloadIcon />}
+                        disabled={isExporting}
+                        onClick={handleExport}
                         fullWidth
                         sx={{ justifyContent: 'flex-start' }}
                       >
-                        {t('profile.general.exportData')}
+                        {isExporting ? t('common.loading') : t('profile.general.exportData')}
                       </Button>
                     </span>
                   </Tooltip>

--- a/app/frontend/src/services/userService.ts
+++ b/app/frontend/src/services/userService.ts
@@ -19,3 +19,10 @@ export const deleteUser = async (userId: string): Promise<void> => {
 export const deleteMe = async (): Promise<void> => {
   await api.delete('/users/me');
 };
+
+export const exportData = async (): Promise<Blob> => {
+  const { data } = await api.get('/users/me/export', {
+    responseType: 'blob',
+  });
+  return data;
+};

--- a/plans/20260120-2150--feature_personal_data_export.md
+++ b/plans/20260120-2150--feature_personal_data_export.md
@@ -1,0 +1,156 @@
+# Implementation Plan - Personal Data Export & Frontend Integration
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Implement a GDPR-compliant data export (JSON) accessible via a user profile button. Logic will be encapsulated in a Service for better testing.
+*   **Affected Files:**
+    *   Backend: `api/NikoNiko.Services/IUserService.cs`, `api/NikoNiko.Services/UserService.cs`, `api/NikoNiko.Api/Controllers/UsersController.cs`, `api/NikoNiko.Api/Program.cs`, `api/NikoNiko.Core/DTOs/User/Export/`
+    *   Frontend: `app/frontend/src/services/userService.ts`, `app/frontend/src/pages/ProfilePage.tsx`
+*   **Key Dependencies:** `ApplicationDbContext`, `SHA256` for hashing.
+
+## 2. 📋 Checklist
+- [x] Step 1: Create Export DTOs.
+- [x] Step 2: Implement `UserService` with Export Logic.
+- [x] Step 3: Register Service & Update `UsersController`.
+- [x] Step 4: Add Integration Test.
+- [x] Step 5: Frontend Service & Component Update.
+- [x] Verification: Full E2E test.
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+5. **No Stealth Actions**: NEVER execute code or modify files without having first updated the plan to reflect that you are about to do so.
+
+### Step 1: Create Export DTOs
+*   **Goal:** Define the JSON structure.
+*   **Status:** [x] Done
+*   **Action:**
+    *   Create directory `api/NikoNiko.Core/DTOs/User/Export`.
+    *   Create `api/NikoNiko.Core/DTOs/User/Export/UserExportDto.cs`:
+        ```csharp
+        namespace NikoNiko.Core.DTOs.User.Export;
+
+        public class UserExportDto
+        {
+            public IdentityExportDto Identity { get; set; } = new();
+            public List<TeamExportDto> Teams { get; set; } = new();
+            public List<MoodExportDto> History { get; set; } = new();
+        }
+
+        public class IdentityExportDto
+        {
+            public string OpenId { get; set; } = string.Empty;
+            public string Username { get; set; } = string.Empty;
+            public string? Provider { get; set; }
+            public DateTime JoinedAt { get; set; }
+        }
+
+        public class TeamExportDto
+        {
+            public string Id { get; set; } = string.Empty; // Normalized ID
+            public string Name { get; set; } = string.Empty;
+            public int MemberCount { get; set; }
+        }
+
+        public class MoodExportDto
+        {
+            public DateTime Date { get; set; }
+            public string Mood { get; set; } = string.Empty;
+            public string TeamId { get; set; } = string.Empty; // Normalized ID reference
+        }
+        ```
+
+### Step 2: Implement UserService
+*   **Goal:** Encapsulate export logic.
+*   **Status:** [x] Done
+*   **Action:**
+    *   Create `api/NikoNiko.Services/IUserService.cs`
+    *   Create `api/NikoNiko.Services/UserService.cs`
+
+### Step 3: Register Service & Update Controller
+*   **Goal:** Expose the feature via API.
+*   **Status:** [x] Done
+*   **Action:**
+    *   In `api/NikoNiko.Api/Program.cs`:
+        *   Add `builder.Services.AddScoped<IUserService, UserService>();` (after other services).
+    *   In `api/NikoNiko.Api/Controllers/UsersController.cs`:
+        *   Inject `IUserService`.
+        *   Add endpoint:
+        ```csharp
+        [HttpGet("me/export")]
+        [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ExportData([FromServices] IUserService userService)
+        {
+            var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!Guid.TryParse(userIdString, out var userId))
+            {
+                return Unauthorized();
+            }
+
+            var exportDto = await userService.GetExportDataAsync(userId);
+            if (exportDto == null)
+            {
+                return NotFound();
+            }
+
+            var jsonBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(exportDto, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+            var fileName = $"nikoniko-export-{DateTime.UtcNow:yyyyMMdd}.json";
+            
+            return File(jsonBytes, "application/json", fileName);
+        }
+        ```
+
+### Step 4: Add Integration Test
+*   **Goal:** Verify JSON output automatically.
+*   **Status:** [x] Done
+*   **Action:**
+    *   Create `api/NikoNiko.Api.IntegrationTests/UsersControllerExportTests.cs`
+    *   Include a test that creates a user, team, mood, requests export, and asserts the response.
+
+### Step 5: Frontend Implementation
+*   **Goal:** User Interface for export.
+*   **Status:** [x] Done
+*   **Action:**
+    *   In `app/frontend/src/services/userService.ts`:
+        ```typescript
+        export const exportData = async (): Promise<Blob> => {
+          const response = await axiosInstance.get('/users/me/export', {
+            responseType: 'blob',
+          });
+          return response.data;
+        };
+        ```
+    *   In `app/frontend/src/pages/ProfilePage.tsx`:
+        *   Import `exportData` from service.
+        *   Add `handleExport`:
+        ```typescript
+        const handleExport = async () => {
+          try {
+            const blob = await exportData();
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `nikoniko-export-${new Date().toISOString().split('T')[0]}.json`;
+            document.body.appendChild(a);
+            a.click();
+            window.URL.revokeObjectURL(url);
+            document.body.removeChild(a);
+          } catch (error) {
+            console.error('Export failed', error);
+            enqueueSnackbar(t('common.error'), { variant: 'error' });
+          }
+        };
+        ```
+        *   Connect to button `onClick={handleExport}` and remove `disabled`.
+
+## 4. 🧪 Testing Strategy
+*   **Integration:** `UsersControllerExportTests` will cover the data integrity.
+*   **Manual E2E:** Click button in Frontend, verify file download and content.
+
+## 5. ✅ Success Criteria
+*   Backend tests pass.
+*   Profile page button downloads a valid JSON file.


### PR DESCRIPTION
## Summary
This PR implements the personal data export feature, allowing users to download a comprehensive JSON file containing their account information, team memberships, and mood history. This addition supports GDPR compliance regarding data portability.

## Key Changes
- **Backend Service**: Introduced `UserService` (and `IUserService`) to encapsulate the logic for fetching user data and generating a stable, anonymized hash for team IDs.
- **API Endpoint**: Added `GET /api/users/me/export` to `UsersController` which streams the generated JSON file.
- **Data Models**: Created `UserExportDto`, `TeamExportDto`, `MoodExportDto`, and `IdentityExportDto` to define the export structure.
- **Frontend**: Updated `ProfilePage.tsx` to activate the "Export Data" button with loading state management and file download handling via `userService.ts`.
- **Testing**: Added `UsersControllerExportTests` integration tests to verify the JSON structure, content integrity, and ID anonymization.

## Checklist
- [x] Tests passed (Integration tests added)
- [x] Documentation updated (Swagger/OpenAPI implicitly updated via Controller attributes)

---

Closes #50