### PR TITLE
feat(sprints): allow updating sprint dates with mood entry validation 📅

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/SprintsControllerUpdateTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/SprintsControllerUpdateTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NikoNiko.Core.DTOs.Sprint;
+using NikoNiko.Core.Models;
+using NikoNiko.Data;
+using Xunit;
+
+namespace NikoNiko.Api.IntegrationTests;
+
+public class SprintsControllerUpdateTests
+{
+    private DateTime GetUtcDate(int addDays = 0)
+    {
+        return DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(addDays), DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task UpdateSprint_WithNoMoods_ShouldSuccess()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (teamAdmin, client, _) = await application.CreateUserAndClient("Team Admin");
+        var team = await application.CreateTeam("Test Team", teamAdmin.Id);
+
+        var createSprintDto = new CreateSprintDto
+        {
+            Name = "Sprint 1",
+            TeamId = team.Id,
+            StartDate = GetUtcDate(),
+            EndDate = GetUtcDate(10)
+        };
+        var createResponse = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
+        var sprint = await createResponse.Content.ReadFromJsonAsync<SprintDto>();
+        Assert.NotNull(sprint);
+
+        var updateDto = new UpdateSprintDto
+        {
+            Name = "Sprint 1 Updated",
+            StartDate = sprint.StartDate.AddDays(1),
+            EndDate = sprint.EndDate.AddDays(-1)
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/sprints/{sprint.Id}", updateDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        
+        using var scope = application.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var updatedSprint = await dbContext.Sprints.FindAsync(sprint.Id);
+        Assert.NotNull(updatedSprint);
+        
+        Assert.Equal("Sprint 1 Updated", updatedSprint.Name);
+        Assert.Equal(updateDto.StartDate.ToUniversalTime(), updatedSprint.StartDate);
+        Assert.Equal(updateDto.EndDate.ToUniversalTime(), updatedSprint.EndDate);
+    }
+
+    [Fact]
+    public async Task UpdateSprint_WithMoods_ValidDates_ShouldSuccess()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (teamAdmin, client, _) = await application.CreateUserAndClient("Team Admin");
+        var team = await application.CreateTeam("Test Team", teamAdmin.Id);
+
+        var startDate = GetUtcDate();
+        var endDate = GetUtcDate(10);
+        
+        var createSprintDto = new CreateSprintDto
+        {
+            Name = "Sprint 1",
+            TeamId = team.Id,
+            StartDate = startDate,
+            EndDate = endDate
+        };
+        var createResponse = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
+        var sprint = await createResponse.Content.ReadFromJsonAsync<SprintDto>();
+        Assert.NotNull(sprint);
+
+        // Add a mood entry in the middle
+        var moodDate = startDate.AddDays(5);
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            dbContext.MoodEntries.Add(new MoodEntry
+            {
+                SprintId = sprint.Id,
+                UserId = teamAdmin.Id,
+                Date = moodDate,
+                Mood = MoodType.Happy
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        // Try to shrink range but include the mood date
+        var updateDto = new UpdateSprintDto
+        {
+            Name = "Sprint 1 Updated",
+            StartDate = moodDate,
+            EndDate = moodDate.AddDays(1) // Must be > StartDate
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/sprints/{sprint.Id}", updateDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateSprint_WithMoods_InvalidStartDate_ShouldFail()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (teamAdmin, client, _) = await application.CreateUserAndClient("Team Admin");
+        var team = await application.CreateTeam("Test Team", teamAdmin.Id);
+
+        var startDate = GetUtcDate();
+        var endDate = GetUtcDate(10);
+        
+        var createSprintDto = new CreateSprintDto
+        {
+            Name = "Sprint 1",
+            TeamId = team.Id,
+            StartDate = startDate,
+            EndDate = endDate
+        };
+        var createResponse = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
+        var sprint = await createResponse.Content.ReadFromJsonAsync<SprintDto>();
+        Assert.NotNull(sprint);
+
+        // Add a mood entry
+        var moodDate = startDate.AddDays(2);
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            dbContext.MoodEntries.Add(new MoodEntry
+            {
+                SprintId = sprint.Id,
+                UserId = teamAdmin.Id,
+                Date = moodDate,
+                Mood = MoodType.Happy
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        // Try to set start date AFTER the mood date
+        var updateDto = new UpdateSprintDto
+        {
+            Name = "Sprint 1 Updated",
+            StartDate = moodDate.AddDays(1), // Invalid
+            EndDate = endDate
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/sprints/{sprint.Id}", updateDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateSprint_WithMoods_InvalidEndDate_ShouldFail()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (teamAdmin, client, _) = await application.CreateUserAndClient("Team Admin");
+        var team = await application.CreateTeam("Test Team", teamAdmin.Id);
+
+        var startDate = GetUtcDate();
+        var endDate = GetUtcDate(10);
+        
+        var createSprintDto = new CreateSprintDto
+        {
+            Name = "Sprint 1",
+            TeamId = team.Id,
+            StartDate = startDate,
+            EndDate = endDate
+        };
+        var createResponse = await client.PostAsJsonAsync("/api/sprints", createSprintDto);
+        var sprint = await createResponse.Content.ReadFromJsonAsync<SprintDto>();
+        Assert.NotNull(sprint);
+
+        // Add a mood entry
+        var moodDate = startDate.AddDays(8);
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            dbContext.MoodEntries.Add(new MoodEntry
+            {
+                SprintId = sprint.Id,
+                UserId = teamAdmin.Id,
+                Date = moodDate,
+                Mood = MoodType.Happy
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        // Try to set end date BEFORE the mood date
+        var updateDto = new UpdateSprintDto
+        {
+            Name = "Sprint 1 Updated",
+            StartDate = startDate,
+            EndDate = moodDate.AddDays(-1) // Invalid
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/sprints/{sprint.Id}", updateDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/api/NikoNiko.Api/Controllers/SprintsController.cs
+++ b/api/NikoNiko.Api/Controllers/SprintsController.cs
@@ -169,6 +169,71 @@ public class SprintsController : ControllerBase
     }
 
     /// <summary>
+    /// Updates a sprint.
+    /// Only the team's admin or a super-admin can update a sprint.
+    /// </summary>
+    /// <param name="sprintId">The ID of the sprint to update.</param>
+    /// <param name="updateSprintDto">The new data for the sprint.</param>
+    /// <returns>NoContent if successful, or an error response.</returns>
+    [HttpPut("{sprintId}")]
+    [Authorize(Policy = "IsTeamAdmin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UpdateSprint(Guid sprintId, UpdateSprintDto updateSprintDto)
+    {
+        var sprint = await _context.Sprints
+            .Include(s => s.MoodEntries)
+            .FirstOrDefaultAsync(s => s.Id == sprintId);
+
+        if (sprint == null)
+        {
+            return NotFound();
+        }
+
+        if (updateSprintDto.EndDate <= updateSprintDto.StartDate)
+        {
+            ModelState.AddModelError(nameof(updateSprintDto.EndDate), "End date must be after start date.");
+            return BadRequest(ModelState);
+        }
+
+        var newStart = updateSprintDto.StartDate.ToUniversalTime();
+        var newEnd = updateSprintDto.EndDate.ToUniversalTime();
+
+        // Validate date range against existing mood entries
+        if (sprint.MoodEntries.Any())
+        {
+            var minMoodDate = sprint.MoodEntries.Min(m => m.Date);
+            var maxMoodDate = sprint.MoodEntries.Max(m => m.Date);
+
+            if (newStart > minMoodDate)
+            {
+                ModelState.AddModelError(nameof(updateSprintDto.StartDate), $"Cannot set start date after {minMoodDate:yyyy-MM-dd} because there are existing mood entries.");
+            }
+
+            if (newEnd < maxMoodDate)
+            {
+                ModelState.AddModelError(nameof(updateSprintDto.EndDate), $"Cannot set end date before {maxMoodDate:yyyy-MM-dd} because there are existing mood entries.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+        }
+
+        sprint.Name = updateSprintDto.Name;
+        sprint.StartDate = newStart;
+        sprint.EndDate = newEnd;
+
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    /// <summary>
     /// Deletes a sprint.
     /// Only the team's admin or a super-admin can delete a sprint.
     /// </summary>

--- a/api/NikoNiko.Core/DTOs/Sprint/UpdateSprintDto.cs
+++ b/api/NikoNiko.Core/DTOs/Sprint/UpdateSprintDto.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NikoNiko.Core.DTOs.Sprint;
+
+/// <summary>
+/// Represents the data needed to update an existing sprint.
+/// </summary>
+public record UpdateSprintDto
+{
+    /// <summary>
+    /// The name of the sprint.
+    /// </summary>
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; init; } = null!;
+
+    /// <summary>
+    /// The start date of the sprint.
+    /// </summary>
+    [Required]
+    public DateTime StartDate { get; init; }
+
+    /// <summary>
+    /// The end date of the sprint.
+    /// </summary>
+    [Required]
+    public DateTime EndDate { get; init; }
+}

--- a/app/frontend/src/components/AdminEditSprintDialog.tsx
+++ b/app/frontend/src/components/AdminEditSprintDialog.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { isAxiosError } from 'axios';
+
+import type { Sprint } from '@/models/Sprint';
+import type { UpdateSprint } from '@/models/UpdateSprint';
+import { updateSprint } from '@/services/sprintService';
+
+interface AdminEditSprintDialogProps {
+  sprint: Sprint | null;
+  open: boolean;
+  onClose: () => void;
+  onSprintUpdated: () => void;
+}
+
+const AdminEditSprintDialog: React.FC<AdminEditSprintDialogProps> = ({
+  sprint,
+  open,
+  onClose,
+  onSprintUpdated,
+}) => {
+  const { t } = useTranslation();
+  const [name, setName] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (sprint && open) {
+      setName(sprint.name);
+      // Format dates to YYYY-MM-DD for the input type="date"
+      setStartDate(new Date(sprint.startDate).toISOString().split('T')[0]);
+      setEndDate(new Date(sprint.endDate).toISOString().split('T')[0]);
+      setError(null);
+    }
+  }, [sprint, open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!sprint) return;
+
+    setError(null);
+    setIsSubmitting(true);
+
+    if (!name || !startDate || !endDate) {
+      setError(t('adminSprints.createForm.errorFill'));
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (new Date(startDate) >= new Date(endDate)) {
+      setError(t('adminSprints.createForm.errorDate'));
+      setIsSubmitting(false);
+      return;
+    }
+
+    const updatedSprint: UpdateSprint = {
+      name,
+      startDate,
+      endDate,
+    };
+
+    try {
+      await updateSprint(sprint.id, updatedSprint);
+      onSprintUpdated();
+      onClose();
+    } catch (err) {
+      // Check if it's a validation error from API (400 BadRequest)
+      if (isAxiosError(err) && err.response?.status === 400) {
+        setError(t('adminSprints.editDialog.errorFail'));
+      } else {
+        setError(t('common.error'));
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{t('adminSprints.editDialog.title')}</DialogTitle>
+      <Box component="form" onSubmit={handleSubmit}>
+        <DialogContent>
+          {error && (
+            <Typography color="error" variant="body2" sx={{ mb: 2 }}>
+              {error}
+            </Typography>
+          )}
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12 }}>
+              <TextField
+                id="edit-sprint-name"
+                label={t('adminSprints.createForm.nameLabel')}
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                fullWidth
+                required
+                disabled={isSubmitting}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                id="edit-start-date"
+                label={t('adminSprints.createForm.startDateLabel')}
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                fullWidth
+                required
+                disabled={isSubmitting}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                id="edit-end-date"
+                label={t('adminSprints.createForm.endDateLabel')}
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                fullWidth
+                required
+                disabled={isSubmitting}
+              />
+            </Grid>
+          </Grid>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={isSubmitting}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" variant="contained" color="primary" disabled={isSubmitting}>
+            {isSubmitting ? t('common.loading') : t('common.save')}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+};
+
+export default AdminEditSprintDialog;

--- a/app/frontend/src/i18n/locales/en.json
+++ b/app/frontend/src/i18n/locales/en.json
@@ -187,6 +187,11 @@
       "errorFill": "Please fill in all fields and select a team.",
       "errorDate": "End date must be after start date.",
       "errorFail": "Failed to create sprint. Please try again."
+    },
+    "editDialog": {
+      "title": "Edit Sprint",
+      "success": "Sprint updated successfully!",
+      "errorFail": "Failed to update sprint. Dates might be invalid compared to existing mood entries."
     }
   },
   "profile": {

--- a/app/frontend/src/i18n/locales/fr.json
+++ b/app/frontend/src/i18n/locales/fr.json
@@ -187,6 +187,11 @@
       "errorFill": "Veuillez remplir tous les champs et sélectionner une équipe.",
       "errorDate": "La date de fin doit être postérieure à la date de début.",
       "errorFail": "Échec de la création du sprint. Veuillez réessayer."
+    },
+    "editDialog": {
+      "title": "Modifier le Sprint",
+      "success": "Sprint mis à jour avec succès !",
+      "errorFail": "Échec de la mise à jour du sprint. Les dates pourraient être invalides par rapport aux entrées d'humeur existantes."
     }
   },
   "profile": {

--- a/app/frontend/src/models/UpdateSprint.ts
+++ b/app/frontend/src/models/UpdateSprint.ts
@@ -1,0 +1,5 @@
+export interface UpdateSprint {
+  name: string;
+  startDate: string;
+  endDate: string;
+}

--- a/app/frontend/src/pages/AdminSprintsPage.tsx
+++ b/app/frontend/src/pages/AdminSprintsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import {
   Box,
@@ -26,6 +27,7 @@ import type { Sprint } from '@/models/Sprint';
 import { deleteSprint } from '@/services/sprintService';
 
 import AdminCreateSprintForm from '@/components/AdminCreateSprintForm';
+import AdminEditSprintDialog from '@/components/AdminEditSprintDialog';
 import PageContainer from '@/components/layout/PageContainer';
 
 const AdminSprintsPage: React.FC = () => {
@@ -35,9 +37,15 @@ const AdminSprintsPage: React.FC = () => {
   const { enqueueSnackbar } = useSnackbar();
 
   const [sprintToDelete, setSprintToDelete] = useState<Sprint | null>(null);
+  const [sprintToEdit, setSprintToEdit] = useState<Sprint | null>(null);
 
   const handleSprintCreated = () => {
     enqueueSnackbar(t('adminSprints.createForm.success'), { variant: 'success' });
+    mutateSprints();
+  };
+
+  const handleSprintUpdated = () => {
+    enqueueSnackbar(t('adminSprints.editDialog.success'), { variant: 'success' });
     mutateSprints();
   };
 
@@ -45,8 +53,16 @@ const AdminSprintsPage: React.FC = () => {
     setSprintToDelete(sprint);
   };
 
+  const handleEditClick = (sprint: Sprint) => {
+    setSprintToEdit(sprint);
+  };
+
   const handleCloseDeleteDialog = () => {
     setSprintToDelete(null);
+  };
+
+  const handleCloseEditDialog = () => {
+    setSprintToEdit(null);
   };
 
   const handleConfirmDelete = async () => {
@@ -119,15 +135,25 @@ const AdminSprintsPage: React.FC = () => {
                     {new Date(sprint.endDate).toLocaleDateString()}
                   </Typography>
 
-                  {/* Delete Button */}
-                  <IconButton
-                    onClick={() => handleDeleteClick(sprint)}
-                    color="error"
-                    size="small"
-                    aria-label="delete"
-                  >
-                    <DeleteIcon />
-                  </IconButton>
+                  {/* Actions */}
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    <IconButton
+                      onClick={() => handleEditClick(sprint)}
+                      color="primary"
+                      size="small"
+                      aria-label="edit"
+                    >
+                      <EditIcon />
+                    </IconButton>
+                    <IconButton
+                      onClick={() => handleDeleteClick(sprint)}
+                      color="error"
+                      size="small"
+                      aria-label="delete"
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Box>
                 </Box>
               </ListItem>
             ))
@@ -136,6 +162,14 @@ const AdminSprintsPage: React.FC = () => {
           )}
         </List>
       )}
+
+      {/* Edit Dialog */}
+      <AdminEditSprintDialog
+        open={sprintToEdit !== null}
+        sprint={sprintToEdit}
+        onClose={handleCloseEditDialog}
+        onSprintUpdated={handleSprintUpdated}
+      />
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={sprintToDelete !== null} onClose={handleCloseDeleteDialog}>

--- a/app/frontend/src/services/sprintService.ts
+++ b/app/frontend/src/services/sprintService.ts
@@ -1,5 +1,6 @@
 import type { CreateSprint } from '@/models/CreateSprint';
 import type { Sprint } from '@/models/Sprint';
+import type { UpdateSprint } from '@/models/UpdateSprint';
 
 import api from './api';
 
@@ -17,6 +18,10 @@ export const getSprintById = async (sprintId: string): Promise<Sprint> => {
 export const createSprint = async (sprint: CreateSprint): Promise<Sprint> => {
   const { data } = await api.post('/sprints', sprint);
   return data;
+};
+
+export const updateSprint = async (sprintId: string, sprint: UpdateSprint): Promise<void> => {
+  await api.put(`/sprints/${sprintId}`, sprint);
 };
 
 export const deleteSprint = async (sprintId: string): Promise<void> => {

--- a/plans/20260120-2203--feature_sprint_update.md
+++ b/plans/20260120-2203--feature_sprint_update.md
@@ -1,0 +1,125 @@
+# Implementation Plan - Feature: Sprint Update with Date Validation
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Allow team admins to update sprint start/end dates. Ensure validation prevents excluding existing mood entries (Issue #33).
+*   **Affected Files:**
+    *   Backend: `api/NikoNiko.Core/DTOs/Sprint/UpdateSprintDto.cs` (New), `api/NikoNiko.Api/Controllers/SprintsController.cs`
+    *   Frontend: `app/frontend/src/services/sprintService.ts`, `app/frontend/src/models/UpdateSprint.ts` (New), `app/frontend/src/pages/AdminSprintsPage.tsx`, `app/frontend/src/components/AdminEditSprintDialog.tsx` (New/Refactor)
+*   **Key Dependencies:** `ApplicationDbContext` (for checking MoodEntries).
+*   **Risks/Unknowns:** Timezone handling when comparing dates. Ensuring generic generic `Dialog` components are reusable or create a new one.
+
+## 2. 📋 Checklist
+- [x] Step 1: Create `UpdateSprintDto` in Backend.
+- [x] Step 2: Implement `PUT` endpoint in `SprintsController` with validation logic.
+- [x] Step 3: Create Integration Tests for Sprint Update validation.
+- [x] Step 4: Update Frontend `Sprint` models and `sprintService`.
+- [x] Step 5: Implement `AdminEditSprintDialog` component.
+- [x] Step 6: Integrate Edit button in `AdminSprintsPage`.
+- [x] Verification
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+5. **No Stealth Actions**: NEVER execute code or modify files without having first updated the plan to reflect that you are about to do so.
+
+### Step 1: Create UpdateSprintDto
+*   **Goal:** Define the data structure for updating a sprint.
+*   **Status:** Done
+*   **Action:**
+    *   Create `api/NikoNiko.Core/DTOs/Sprint/UpdateSprintDto.cs`.
+    *   Properties: `Name` (string), `StartDate` (DateTime), `EndDate` (DateTime).
+*   **Verification:** File exists and compiles.
+
+### Step 2: Implement PUT Endpoint in SprintsController
+*   **Goal:** Add the API capability to update a sprint with strict validation.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/Controllers/SprintsController.cs`.
+    *   Add `[HttpPut("{sprintId}")]` method.
+    *   **Logic:**
+        1.  Retrieve sprint by ID including `MoodEntries`.
+        2.  Check permissions (Team Admin or Super Admin).
+        3.  Check `EndDate > StartDate`.
+        4.  **Crucial:** If `sprint.MoodEntries` is not empty:
+            *   Get `minDate = sprint.MoodEntries.Min(m => m.Date)`
+            *   Get `maxDate = sprint.MoodEntries.Max(m => m.Date)`
+            *   Validate `dto.StartDate <= minDate` AND `dto.EndDate >= maxDate`.
+            *   Return `BadRequest` if invalid.
+        5.  Update fields and `SaveChangesAsync`.
+*   **Verification:** Compile backend.
+
+### Step 3: Integration Tests
+*   **Goal:** Verify the validation rules automatically.
+*   **Status:** Done
+*   **Action:**
+    *   Create `api/NikoNiko.Api.IntegrationTests/SprintsControllerUpdateTests.cs`.
+    *   Test cases:
+        *   `UpdateSprint_WithNoMoods_ShouldSuccess`
+        *   `UpdateSprint_WithMoods_ValidDates_ShouldSuccess`
+        *   `UpdateSprint_WithNoMoods_ShouldSuccess`
+        *   `UpdateSprint_WithMoods_InvalidStartDate_ShouldFail`
+        *   `UpdateSprint_WithMoods_InvalidEndDate_ShouldFail`
+*   **Verification:** Run `dotnet test api/NikoNiko.Api.IntegrationTests`.
+
+### Step 4: Frontend Service & Models
+*   **Goal:** Prepare frontend data layer.
+*   **Status:** Done
+*   **Action:**
+    *   Create `app/frontend/src/models/UpdateSprint.ts`.
+    *   Update `app/frontend/src/services/sprintService.ts`: export `updateSprint(id: string, data: UpdateSprint)`.
+*   **Verification:** check types.
+
+### Step 5: AdminEditSprintDialog Component
+*   **Goal:** UI for editing.
+*   **Status:** Done
+*   **Action:**
+    *   Create `app/frontend/src/components/AdminEditSprintDialog.tsx`.
+    *   Use `Dialog` from MUI.
+    *   Inputs: Name, StartDate, EndDate (using standard date pickers or text fields as per existing Create form).
+    *   Handle form submission -> call `updateSprint`.
+    *   Display error message if API returns 400 (validation error).
+*   **Verification:** Component renders.
+
+### Step 6: Integrate into AdminSprintsPage
+*   **Goal:** Connect the UI.
+*   **Status:** Done
+*   **Action:**
+    *   Modify `app/frontend/src/pages/AdminSprintsPage.tsx`.
+    *   Import `AdminEditSprintDialog`.
+    *   Add "Edit" `IconButton` (using `EditIcon`) in the list item.
+    *   Manage `selectedSprint` state to open the dialog.
+    *   Refresh list on success.
+*   **Verification:** Launch app and test flow.
+
+### Step 7: Final Verification
+*   **Goal:** Ensure overall quality.
+*   **Status:** Done
+*   **Action:**
+    *   Run frontend build: `npm run build`.
+    *   Run backend tests again.
+*   **Verification:** All pass.
+*   **Action:**
+    *   Modify `app/frontend/src/pages/AdminSprintsPage.tsx`.
+    *   Import `AdminEditSprintDialog`.
+    *   Add "Edit" `IconButton` (using `EditIcon`) in the list item.
+    *   Manage `selectedSprint` state to open the dialog.
+    *   Refresh list on success.
+*   **Verification:** Launch app and test flow.
+
+## 4. 🧪 Testing Strategy
+*   **Unit/Integration:** Backend integration tests are the source of truth for the logic.
+*   **Manual:**
+    1.  Login as Admin.
+    2.  Create Sprint A (Empty). Edit dates -> OK.
+    3.  Enter Mood for today in Sprint A.
+    4.  Edit Sprint A: Try to set EndDate to yesterday -> Error.
+    5.  Edit Sprint A: Extend EndDate -> OK.
+
+## 5. ✅ Success Criteria
+*   Backend rejects invalid date ranges when moods exist.
+*   Frontend displays a clear error when modification is rejected.
+*   Valid updates are persisted.


### PR DESCRIPTION
## Summary
This PR enables team admins to update the start and end dates of an existing sprint. It includes a critical validation logic to ensure that reducing the sprint duration does not orphan existing mood entries, maintaining data integrity.

## Key Changes
- **Backend:**
    - Implemented `PUT /api/sprints/{sprintId}` endpoint in `SprintsController`.
    - Added logic to validate that new sprint dates cover all existing mood entries (Min/Max date check).
    - Created `UpdateSprintDto` to handle the update payload.
- **Frontend:**
    - Added `UpdateSprint` model and updated `sprintService`.
    - Created `AdminEditSprintDialog` component for editing sprints with date pickers.
    - Integrated an "Edit" button in the `AdminSprintsPage` list.
    - Added translation keys for the new dialog and error messages (EN/FR).
- **Tests:**
    - Added comprehensive integration tests (`SprintsControllerUpdateTests`) covering success scenarios and validation failures (invalid date range, exclusion of mood entries).

## Checklist
- [x] Tests passed (Backend Integration Tests)
- [x] Documentation updated (Swagger/OpenAPI via code)
- [x] Frontend Lint & Build passed

---

Closes #33