### PR TITLE
fix(frontend): remove "coming soon" tooltip from user data export

### DIFF
--- a/app/frontend/src/i18n/locales/en.json
+++ b/app/frontend/src/i18n/locales/en.json
@@ -209,7 +209,6 @@
       "accountInfo": "Account Information",
       "privacyZone": "Privacy & Data",
       "exportData": "Export My Data",
-      "exportTooltip": "Feature coming soon",
       "deleteAccount": "Delete My Account",
       "deleteWarning": "Danger Zone: This action is irreversible."
     },

--- a/app/frontend/src/i18n/locales/fr.json
+++ b/app/frontend/src/i18n/locales/fr.json
@@ -209,7 +209,6 @@
       "accountInfo": "Informations du Compte",
       "privacyZone": "Confidentialité & Données",
       "exportData": "Exporter mes données",
-      "exportTooltip": "Fonctionnalité à venir",
       "deleteAccount": "Supprimer mon compte",
       "deleteWarning": "Zone de danger : Cette action est irréversible."
     },

--- a/app/frontend/src/pages/ProfilePage.tsx
+++ b/app/frontend/src/pages/ProfilePage.tsx
@@ -28,7 +28,6 @@ import {
   TablePagination,
   Tabs,
   TextField,
-  Tooltip,
   Typography,
 } from '@mui/material';
 import dayjs from 'dayjs';
@@ -245,20 +244,16 @@ const ProfilePage = () => {
                   <Typography variant="subtitle1" gutterBottom>
                     {t('profile.general.exportData')}
                   </Typography>
-                  <Tooltip title={t('profile.general.exportTooltip')}>
-                    <span>
-                      <Button
-                        variant="outlined"
-                        startIcon={isExporting ? <CircularProgress size={20} /> : <DownloadIcon />}
-                        disabled={isExporting}
-                        onClick={handleExport}
-                        fullWidth
-                        sx={{ justifyContent: 'flex-start' }}
-                      >
-                        {isExporting ? t('common.loading') : t('profile.general.exportData')}
-                      </Button>
-                    </span>
-                  </Tooltip>
+                  <Button
+                    variant="outlined"
+                    startIcon={isExporting ? <CircularProgress size={20} /> : <DownloadIcon />}
+                    disabled={isExporting}
+                    onClick={handleExport}
+                    fullWidth
+                    sx={{ justifyContent: 'flex-start' }}
+                  >
+                    {isExporting ? t('common.loading') : t('profile.general.exportData')}
+                  </Button>
                 </Box>
 
                 <Box sx={{ mt: 2 }}>

--- a/plans/20260122-2215--fix_export_tooltip.md
+++ b/plans/20260122-2215--fix_export_tooltip.md
@@ -1,0 +1,51 @@
+# Implementation Plan - Fix User Export Tooltip
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Remove the "Feature coming soon" tooltip from the "Export My Data" button on the profile page, as the feature is fully implemented in the backend and frontend.
+*   **Affected Files:**
+    *   `app/frontend/src/pages/ProfilePage.tsx`
+    *   `app/frontend/src/i18n/locales/en.json`
+    *   `app/frontend/src/i18n/locales/fr.json`
+*   **Key Dependencies:** None.
+*   **Risks/Unknowns:** None. The feature `UsersController.ExportData` is implemented in the backend.
+
+## 2. 📋 Checklist
+- [x] Step 1: Remove Tooltip wrapper in ProfilePage
+- [x] Step 2: Clean up i18n keys
+- [x] Verification
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+5. **No Stealth Actions**: NEVER execute code or modify files without having first updated the plan to reflect that you are about to do so.
+
+### Step 1: Remove Tooltip wrapper in ProfilePage
+*   **Status:** [x] Done
+*   **Goal:** Make the "Export Data" button directly accessible without the misleading tooltip.
+*   **Action:**
+    *   Modify `app/frontend/src/pages/ProfilePage.tsx`:
+        *   Remove `<Tooltip title={t('profile.general.exportTooltip')}>` and its closing tag.
+        *   Keep the inner `LoadingButton` (or `Button`).
+*   **Verification:** Review file content.
+
+### Step 2: Clean up i18n keys
+*   **Status:** [x] Done
+*   **Goal:** Remove the unused `exportTooltip` translation key.
+*   **Action:**
+    *   Modify `app/frontend/src/i18n/locales/en.json`: Remove `"exportTooltip": "Feature coming soon",`.
+    *   Modify `app/frontend/src/i18n/locales/fr.json`: Remove `"exportTooltip": "Fonctionnalité à venir",`.
+*   **Verification:** Review file content.
+
+## 4. 🧪 Testing Strategy
+*   **Manual Verification:**
+    *   Go to Profile Page.
+    *   Verify "Export Data" button is visible and not wrapped in a "Coming soon" tooltip.
+    *   (Optional) Click the button to ensure the download starts (relies on backend).
+
+## 5. ✅ Success Criteria
+*   The "Export Data" button no longer shows "Feature coming soon".
+*   The codebase is clean of unused translation keys.


### PR DESCRIPTION
## Summary
The backend functionality for exporting user data is fully implemented and operational. However, the frontend User Profile page still displayed a "Feature coming soon" tooltip on the export button. This PR removes that tooltip to reflect the actual availability of the feature and cleans up the associated localization resources.

## Key Changes
- **Frontend (`ProfilePage.tsx`)**: Removed the `Tooltip` wrapper around the "Export My Data" button, making it directly accessible and removing the misleading "coming soon" message.
- **i18n (`en.json`, `fr.json`)**: Removed the unused `exportTooltip` translation keys to keep the locale files clean.
- **Documentation**: Added the implementation plan `plans/20260122-2215--fix_export_tooltip.md`.

## Checklist
- [x] UI updated to reflect feature availability
- [x] Unused translation keys removed
- [x] Manual verification of export functionality (optional but recommended)
