### PR TITLE
feat(teams): add default sprint duration configuration

### DIFF
--- a/api/NikoNiko.Api.IntegrationTests/TeamsControllerDefaultDurationTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/TeamsControllerDefaultDurationTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NikoNiko.Core.DTOs.Team;
+using NikoNiko.Data;
+
+using Xunit;
+
+namespace NikoNiko.Api.IntegrationTests;
+
+public class TeamsControllerDefaultDurationTests
+{
+    [Fact]
+    public async Task UpdateTeam_WithDefaultSprintDuration_PersistsDuration()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (teamAdmin, client, _) = await application.CreateUserAndClient("Team Admin");
+        var team = await application.CreateTeam("Test Team", teamAdmin.Id);
+
+        var updateTeamDto = new UpdateTeamDto
+        {
+            Name = "Updated Team Name",
+            DefaultSprintDuration = 14
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/teams/{team.Id}", updateTeamDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using var scope = application.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var updatedTeam = await dbContext.Teams.FindAsync(team.Id);
+        Assert.NotNull(updatedTeam);
+        Assert.Equal("Updated Team Name", updatedTeam.Name);
+        Assert.Equal(14, updatedTeam.DefaultSprintDuration);
+    }
+
+    [Fact]
+    public async Task UpdateTeam_WithNullDefaultSprintDuration_PersistsNull()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (teamAdmin, client, _) = await application.CreateUserAndClient("Team Admin");
+        var team = await application.CreateTeam("Test Team", teamAdmin.Id);
+
+        // First set it to something
+        using (var scope = application.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var t = await dbContext.Teams.FindAsync(team.Id);
+            t.DefaultSprintDuration = 14;
+            await dbContext.SaveChangesAsync();
+        }
+
+        var updateTeamDto = new UpdateTeamDto
+        {
+            Name = "Updated Team Name",
+            DefaultSprintDuration = null
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/teams/{team.Id}", updateTeamDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using var assertScope = application.Services.CreateScope();
+        var assertDbContext = assertScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var updatedTeam = await assertDbContext.Teams.FindAsync(team.Id);
+        Assert.NotNull(updatedTeam);
+        Assert.Null(updatedTeam.DefaultSprintDuration);
+    }
+
+    [Fact]
+    public async Task CreateTeam_WithDefaultSprintDuration_PersistsDuration()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Super Admin", isSuperAdmin: true);
+        
+        var createTeamDto = new CreateTeamDto 
+        { 
+            Name = "New Team", 
+            DefaultSprintDuration = 10 
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/teams", createTeamDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var teamDto = await response.Content.ReadFromJsonAsync<TeamDto>();
+        Assert.NotNull(teamDto);
+        Assert.Equal(10, teamDto.DefaultSprintDuration);
+
+        using var assertScope = application.Services.CreateScope();
+        var assertDbContext = assertScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var createdTeam = await assertDbContext.Teams.FindAsync(teamDto.Id);
+        Assert.NotNull(createdTeam);
+        Assert.Equal(10, createdTeam.DefaultSprintDuration);
+    }
+
+    [Fact]
+    public async Task UpdateTeam_WithInvalidDuration_ReturnsBadRequest()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (teamAdmin, client, _) = await application.CreateUserAndClient("Team Admin");
+        var team = await application.CreateTeam("Test Team", teamAdmin.Id);
+
+        var updateTeamDto = new UpdateTeamDto 
+        { 
+            Name = "Updated Team Name", 
+            DefaultSprintDuration = -5 
+        };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/teams/{team.Id}", updateTeamDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/api/NikoNiko.Api/Validators/Team/CreateTeamDtoValidator.cs
+++ b/api/NikoNiko.Api/Validators/Team/CreateTeamDtoValidator.cs
@@ -11,5 +11,9 @@ public class CreateTeamDtoValidator : AbstractValidator<CreateTeamDto>
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("validation.required")
             .MaximumLength(100).WithMessage("validation.maxLength_100");
+
+        RuleFor(x => x.DefaultSprintDuration)
+            .GreaterThan(0).WithMessage("validation.greaterThanZero")
+            .When(x => x.DefaultSprintDuration.HasValue);
     }
 }

--- a/api/NikoNiko.Api/Validators/Team/UpdateTeamDtoValidator.cs
+++ b/api/NikoNiko.Api/Validators/Team/UpdateTeamDtoValidator.cs
@@ -11,5 +11,9 @@ public class UpdateTeamDtoValidator : AbstractValidator<UpdateTeamDto>
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("validation.required")
             .MaximumLength(100).WithMessage("validation.maxLength_100");
+
+        RuleFor(x => x.DefaultSprintDuration)
+            .GreaterThan(0).WithMessage("validation.greaterThanZero")
+            .When(x => x.DefaultSprintDuration.HasValue);
     }
 }

--- a/api/NikoNiko.Core/DTOs/Team/CreateTeamDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/CreateTeamDto.cs
@@ -9,4 +9,9 @@ public record CreateTeamDto
     /// The name of the team.
     /// </summary>
     public string Name { get; init; } = null!;
+
+    /// <summary>
+    /// The default duration of a sprint in days.
+    /// </summary>
+    public int? DefaultSprintDuration { get; init; }
 }

--- a/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/TeamDto.cs
@@ -25,4 +25,9 @@ public record TeamDto
     /// The date and time when the team was created.
     /// </summary>
     public DateTime CreatedAt { get; init; }
+
+    /// <summary>
+    /// The default duration of a sprint in days.
+    /// </summary>
+    public int? DefaultSprintDuration { get; init; }
 }

--- a/api/NikoNiko.Core/DTOs/Team/UpdateTeamDto.cs
+++ b/api/NikoNiko.Core/DTOs/Team/UpdateTeamDto.cs
@@ -9,4 +9,9 @@ public record UpdateTeamDto
     /// The new name of the team.
     /// </summary>
     public required string Name { get; init; }
+
+    /// <summary>
+    /// The default duration of a sprint in days.
+    /// </summary>
+    public int? DefaultSprintDuration { get; init; }
 }

--- a/api/NikoNiko.Core/Models/Team.cs
+++ b/api/NikoNiko.Core/Models/Team.cs
@@ -43,6 +43,11 @@ public class Team
     public List<TeamUser> TeamUsers { get; set; } = new();
 
     /// <summary>
+    /// The default duration of a sprint in days.
+    /// </summary>
+    public int? DefaultSprintDuration { get; set; }
+
+    /// <summary>
     /// Navigation property for the sprints associated with this team.
     /// </summary>
     public List<Sprint> Sprints { get; set; } = new();

--- a/api/NikoNiko.Data/Migrations/20260123175004_GDPR_AccountDeletion.cs
+++ b/api/NikoNiko.Data/Migrations/20260123175004_GDPR_AccountDeletion.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/api/NikoNiko.Data/Migrations/20260125153145_AddDefaultSprintDurationToTeam.Designer.cs
+++ b/api/NikoNiko.Data/Migrations/20260125153145_AddDefaultSprintDurationToTeam.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NikoNiko.Data;
 
@@ -10,9 +11,11 @@ using NikoNiko.Data;
 namespace NikoNiko.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260125153145_AddDefaultSprintDurationToTeam")]
+    partial class AddDefaultSprintDurationToTeam
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.2");

--- a/api/NikoNiko.Data/Migrations/20260125153145_AddDefaultSprintDurationToTeam.cs
+++ b/api/NikoNiko.Data/Migrations/20260125153145_AddDefaultSprintDurationToTeam.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NikoNiko.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDefaultSprintDurationToTeam : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DefaultSprintDuration",
+                table: "Teams",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DefaultSprintDuration",
+                table: "Teams");
+        }
+    }
+}

--- a/api/NikoNiko.Services/TeamService.cs
+++ b/api/NikoNiko.Services/TeamService.cs
@@ -43,6 +43,7 @@ public class TeamService : ITeamService
             AdminId = t.AdminId,
             AdminName = t.Admin.Name ?? t.Admin.Email,
             CreatedAt = t.CreatedAt,
+            DefaultSprintDuration = t.DefaultSprintDuration,
             Sprints = t.Sprints.Select(s => new SprintDto
             {
                 Id = s.Id,
@@ -76,6 +77,7 @@ public class TeamService : ITeamService
                 AdminId = t.AdminId,
                 AdminName = t.Admin.Name ?? t.Admin.Email,
                 CreatedAt = t.CreatedAt,
+                DefaultSprintDuration = t.DefaultSprintDuration,
                 Sprints = t.Sprints.Select(s => new SprintDto
                 {
                     Id = s.Id,
@@ -101,7 +103,8 @@ public class TeamService : ITeamService
         var team = new Team
         {
             Name = createTeamDto.Name,
-            AdminId = adminId
+            AdminId = adminId,
+            DefaultSprintDuration = createTeamDto.DefaultSprintDuration
         };
 
         var teamUser = new TeamUser
@@ -122,7 +125,8 @@ public class TeamService : ITeamService
             Name = team.Name,
             AdminId = team.AdminId,
             AdminName = team.Admin.Name ?? team.Admin.Email,
-            CreatedAt = team.CreatedAt
+            CreatedAt = team.CreatedAt,
+            DefaultSprintDuration = team.DefaultSprintDuration
         };
     }
 
@@ -132,6 +136,7 @@ public class TeamService : ITeamService
         if (team == null) throw new KeyNotFoundException("Team not found.");
 
         team.Name = updateTeamDto.Name;
+        team.DefaultSprintDuration = updateTeamDto.DefaultSprintDuration;
         await _context.SaveChangesAsync();
         await _notificationService.NotifyTeamRenamedAsync(team.Id, team.Name);
     }

--- a/app/frontend/src/components/AdminCreateSprintForm.tsx
+++ b/app/frontend/src/components/AdminCreateSprintForm.tsx
@@ -5,11 +5,11 @@ import dayjs from 'dayjs';
 import axios from 'axios';
 
 import type { CreateSprint } from '@/models/CreateSprint';
-import type { TeamDto } from '@/models/Team';
+import type { TeamWithMembersAndSprints } from '@/models/Team/TeamWithMembersAndSprints';
 import { createSprint } from '@/services/sprintService';
 
 interface AdminCreateSprintFormProps {
-  teams: TeamDto[];
+  teams: TeamWithMembersAndSprints[];
   onSprintCreated: () => void;
 }
 
@@ -24,6 +24,29 @@ const AdminCreateSprintForm: React.FC<AdminCreateSprintFormProps> = ({
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [serverErrors, setServerErrors] = useState<Record<string, string[]>>({});
+
+  const handleTeamChange = (teamId: string) => {
+    setSelectedTeamId(teamId);
+    if (!teamId) return;
+
+    const team = teams.find((t) => t.id === teamId);
+    if (!team) return;
+
+    // Find last sprint
+    const lastSprint = team.sprints?.length
+      ? [...team.sprints].sort((a, b) => dayjs(b.endDate).valueOf() - dayjs(a.endDate).valueOf())[0]
+      : null;
+
+    const nextStart = lastSprint ? dayjs(lastSprint.endDate).add(1, 'day') : dayjs();
+    setStartDate(nextStart.format('YYYY-MM-DD'));
+
+    if (team.defaultSprintDuration) {
+      // Subtract 1 day because duration is inclusive
+      setEndDate(nextStart.add(team.defaultSprintDuration - 1, 'day').format('YYYY-MM-DD'));
+    } else {
+      setEndDate('');
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -78,7 +101,7 @@ const AdminCreateSprintForm: React.FC<AdminCreateSprintFormProps> = ({
             id="team-select"
             label={t('adminSprints.createForm.teamLabel')}
             value={selectedTeamId}
-            onChange={(e) => setSelectedTeamId(e.target.value)}
+            onChange={(e) => handleTeamChange(e.target.value)}
             fullWidth
             required
             error={!!serverErrors['TeamId']}

--- a/app/frontend/src/components/AdminTeamListItem.tsx
+++ b/app/frontend/src/components/AdminTeamListItem.tsx
@@ -35,9 +35,9 @@ const AdminTeamListItem: React.FC<AdminTeamListItemProps> = ({ team, onDelete, o
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const { enqueueSnackbar } = useSnackbar();
 
-  const handleUpdateName = async (newName: string) => {
+  const handleUpdateName = async (newName: string, newDuration?: number) => {
     try {
-      await updateTeam(team.id, newName);
+      await updateTeam(team.id, { name: newName, defaultSprintDuration: newDuration });
       enqueueSnackbar(t('dashboard.teamUpdated'), { variant: 'success' });
       if (onUpdate) onUpdate();
     } catch {
@@ -110,6 +110,7 @@ const AdminTeamListItem: React.FC<AdminTeamListItemProps> = ({ team, onDelete, o
         onClose={() => setIsEditDialogOpen(false)}
         onUpdate={handleUpdateName}
         currentName={team.name}
+        currentDefaultSprintDuration={team.defaultSprintDuration}
         members={team.members}
         currentAdminId={team.adminId}
         onTransfer={handleTransferAdmin}

--- a/app/frontend/src/components/CreateTeamForm.tsx
+++ b/app/frontend/src/components/CreateTeamForm.tsx
@@ -19,6 +19,7 @@ const CreateTeamForm: React.FC<CreateTeamFormProps> = ({ onTeamCreated }) => {
   const { t } = useTranslation();
   const { user } = useAuth();
   const [name, setName] = useState('');
+  const [defaultSprintDuration, setDefaultSprintDuration] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [serverErrors, setServerErrors] = useState<Record<string, string[]>>({});
 
@@ -40,12 +41,14 @@ const CreateTeamForm: React.FC<CreateTeamFormProps> = ({ onTeamCreated }) => {
     const newTeam: CreateTeam = {
       name,
       adminId: user.sub,
+      defaultSprintDuration: defaultSprintDuration ? parseInt(defaultSprintDuration, 10) : undefined,
     };
 
     try {
       await createTeam(newTeam);
       onTeamCreated();
       setName('');
+      setDefaultSprintDuration('');
     } catch (err) {
       if (axios.isAxiosError(err) && err.response?.status === 400 && err.response.data.errors) {
         setServerErrors(err.response.data.errors);
@@ -72,6 +75,20 @@ const CreateTeamForm: React.FC<CreateTeamFormProps> = ({ onTeamCreated }) => {
           sx={{ flexGrow: 1 }}
           error={!!serverErrors['Name']}
           helperText={serverErrors['Name'] ? t(serverErrors['Name'][0]) : ''}
+        />
+        <TextField
+          label={t('adminTeams.editDialog.labelDefaultSprintDuration')}
+          type="number"
+          value={defaultSprintDuration}
+          onChange={(e) => setDefaultSprintDuration(e.target.value)}
+          variant="outlined"
+          size="small"
+          slotProps={{ htmlInput: { min: 1 } }}
+          sx={{ width: '200px' }}
+          error={!!serverErrors['DefaultSprintDuration']}
+          helperText={
+            serverErrors['DefaultSprintDuration'] ? t(serverErrors['DefaultSprintDuration'][0]) : ''
+          }
         />
         <Button type="submit" variant="contained" color="primary" sx={{ height: '40px' }}>
           {t('adminTeams.createForm.createButton')}

--- a/app/frontend/src/components/EditTeamDialog.tsx
+++ b/app/frontend/src/components/EditTeamDialog.tsx
@@ -22,8 +22,9 @@ import type { User } from '@/models/User';
 interface EditTeamDialogProps {
   open: boolean;
   onClose: () => void;
-  onUpdate: (newName: string) => Promise<void>;
+  onUpdate: (newName: string, newDefaultSprintDuration?: number) => Promise<void>;
   currentName: string;
+  currentDefaultSprintDuration?: number;
   members?: User[];
   currentAdminId?: string;
   onTransfer?: (newAdminId: string) => Promise<void>;
@@ -34,26 +35,34 @@ const EditTeamDialog: React.FC<EditTeamDialogProps> = ({
   onClose,
   onUpdate,
   currentName,
+  currentDefaultSprintDuration,
   members,
   currentAdminId,
   onTransfer,
 }) => {
   const { t } = useTranslation();
   const [name, setName] = useState(currentName);
+  const [defaultSprintDuration, setDefaultSprintDuration] = useState<string>(
+    currentDefaultSprintDuration?.toString() || '',
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedAdminId, setSelectedAdminId] = useState<string>('');
   const [transferError, setTransferError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim() || name === currentName) {
+    const duration = defaultSprintDuration ? parseInt(defaultSprintDuration, 10) : undefined;
+    const nameChanged = name.trim() !== currentName;
+    const durationChanged = duration !== currentDefaultSprintDuration;
+
+    if (!name.trim() || (!nameChanged && !durationChanged)) {
       onClose();
       return;
     }
 
     setIsSubmitting(true);
     try {
-      await onUpdate(name);
+      await onUpdate(name, duration);
       onClose();
     } catch (error) {
       console.error('Failed to update team name:', error);
@@ -79,6 +88,9 @@ const EditTeamDialog: React.FC<EditTeamDialogProps> = ({
 
   const availableMembers = members?.filter((m) => m.id !== currentAdminId) || [];
 
+  const durationInt = defaultSprintDuration ? parseInt(defaultSprintDuration, 10) : undefined;
+  const hasChanges = name.trim() !== currentName || durationInt !== currentDefaultSprintDuration;
+
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>{t('adminTeams.editDialog.title')}</DialogTitle>
@@ -95,6 +107,18 @@ const EditTeamDialog: React.FC<EditTeamDialogProps> = ({
             onChange={(e) => setName(e.target.value)}
             disabled={isSubmitting}
             required
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            margin="dense"
+            label={t('adminTeams.editDialog.labelDefaultSprintDuration')}
+            type="number"
+            fullWidth
+            variant="outlined"
+            value={defaultSprintDuration}
+            onChange={(e) => setDefaultSprintDuration(e.target.value)}
+            disabled={isSubmitting}
+            slotProps={{ htmlInput: { min: 1 } }}
             sx={{ mb: 2 }}
           />
 
@@ -156,7 +180,7 @@ const EditTeamDialog: React.FC<EditTeamDialogProps> = ({
             type="submit"
             color="primary"
             variant="contained"
-            disabled={isSubmitting || !name.trim() || name === currentName}
+            disabled={isSubmitting || !name.trim() || !hasChanges}
           >
             {t('common.save')}
           </Button>

--- a/app/frontend/src/i18n/locales/en.json
+++ b/app/frontend/src/i18n/locales/en.json
@@ -76,6 +76,7 @@
   },
   "validation": {
     "required": "This field is required",
+    "greaterThanZero": "Must be greater than zero",
     "maxLength_100": "Must be 100 characters or less",
     "endDateBeforeStartDate": "End date must be after start date"
   },
@@ -111,6 +112,7 @@
     "editDialog": {
       "title": "Edit Team Name",
       "labelName": "Team Name",
+      "labelDefaultSprintDuration": "Default Sprint Duration (days)",
       "transferError": "Error transferring administration.",
       "transferWarning": "Warning: Transferring administration is irreversible. You will lose administrative rights to this team.",
       "transferButton": "Transfer Administration",

--- a/app/frontend/src/i18n/locales/fr.json
+++ b/app/frontend/src/i18n/locales/fr.json
@@ -76,6 +76,7 @@
   },
   "validation": {
     "required": "Ce champ est requis",
+    "greaterThanZero": "Doit être supérieur à zéro",
     "maxLength_100": "Doit faire 100 caractères ou moins",
     "endDateBeforeStartDate": "La date de fin doit être après la date de début"
   },
@@ -111,6 +112,7 @@
     "editDialog": {
       "title": "Modifier le nom de l'équipe",
       "labelName": "Nom de l'équipe",
+      "labelDefaultSprintDuration": "Durée par défaut du sprint (jours)",
       "transferError": "Erreur lors du transfert de l'administration.",
       "transferWarning": "Attention : Le transfert de l'administration est irréversible. Vous perdrez les droits d'administration sur cette équipe.",
       "transferButton": "Transférer l'administration",

--- a/app/frontend/src/models/CreateTeam.ts
+++ b/app/frontend/src/models/CreateTeam.ts
@@ -1,4 +1,5 @@
 export interface CreateTeam {
   name: string;
   adminId: string;
+  defaultSprintDuration?: number;
 }

--- a/app/frontend/src/models/Team.ts
+++ b/app/frontend/src/models/Team.ts
@@ -4,4 +4,5 @@ export interface TeamDto {
   adminId: string;
   adminName: string;
   createdAt: string; // Dates are strings over HTTP
+  defaultSprintDuration?: number;
 }

--- a/app/frontend/src/models/Team/TeamWithSprintsDto.ts
+++ b/app/frontend/src/models/Team/TeamWithSprintsDto.ts
@@ -6,6 +6,7 @@ export interface TeamWithSprintsDto {
   name: string;
   adminId: string;
   createdAt: string;
+  defaultSprintDuration?: number;
   sprints: Sprint[];
   members: User[];
 }

--- a/app/frontend/src/pages/CurrentSprintsPage.tsx
+++ b/app/frontend/src/pages/CurrentSprintsPage.tsx
@@ -113,9 +113,9 @@ const TeamCurrentSprintSection: React.FC<TeamCurrentSprintSectionProps> = ({ tea
     return <Typography color="error">{t('common.error')}</Typography>;
   }
 
-  const handleUpdateName = async (newName: string) => {
+  const handleUpdateName = async (newName: string, newDuration?: number) => {
     try {
-      await updateTeam(team.id, newName);
+      await updateTeam(team.id, { name: newName, defaultSprintDuration: newDuration });
       enqueueSnackbar(t('dashboard.teamUpdated'), { variant: 'success' });
       onUpdate();
     } catch {
@@ -196,6 +196,7 @@ const TeamCurrentSprintSection: React.FC<TeamCurrentSprintSectionProps> = ({ tea
         onClose={() => setIsEditDialogOpen(false)}
         onUpdate={handleUpdateName}
         currentName={team.name}
+        currentDefaultSprintDuration={team.defaultSprintDuration}
         members={team.members}
         currentAdminId={team.adminId}
         onTransfer={handleTransferAdmin}

--- a/app/frontend/src/services/teamService.ts
+++ b/app/frontend/src/services/teamService.ts
@@ -24,8 +24,11 @@ export const deleteTeam = async (teamId: string): Promise<void> => {
   await api.delete(`/teams/${teamId}`);
 };
 
-export const updateTeam = async (teamId: string, name: string): Promise<void> => {
-  await api.put(`/teams/${teamId}`, { name });
+export const updateTeam = async (
+  teamId: string,
+  data: { name: string; defaultSprintDuration?: number },
+): Promise<void> => {
+  await api.put(`/teams/${teamId}`, data);
 };
 
 export const transferTeamAdmin = async (teamId: string, newAdminId: string): Promise<void> => {

--- a/plans/20260125-1627--default_sprint_duration.md
+++ b/plans/20260125-1627--default_sprint_duration.md
@@ -1,0 +1,100 @@
+# Implementation Plan - Default Sprint Duration
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Allow Team Admins to configure a default sprint duration. This duration will be used to pre-fill the end date when creating a new sprint. Additionally, the new sprint's start date should default to the day after the last sprint's end date.
+*   **Affected Files:**
+    *   `api/NikoNiko.Core/Models/Team.cs`
+    *   `api/NikoNiko.Core/DTOs/Team/TeamDto.cs`
+    *   `api/NikoNiko.Core/DTOs/Team/UpdateTeamDto.cs`
+    *   `api/NikoNiko.Core/DTOs/Team/CreateTeamDto.cs`
+    *   `api/NikoNiko.Services/TeamService.cs`
+    *   `app/frontend/src/models/Team.ts` (and related interfaces)
+    *   `app/frontend/src/services/teamService.ts`
+    *   `app/frontend/src/components/EditTeamDialog.tsx`
+    *   `app/frontend/src/components/AdminCreateSprintForm.tsx`
+    *   `app/frontend/src/components/CreateTeamForm.tsx`
+*   **Key Dependencies:** Entity Framework Core (Migrations), React, Material UI, dayjs.
+*   **Risks/Unknowns:** Ensuring date calculations account for timezones correctly (using `dayjs` and ISO strings should mitigate this). Ensuring `AdminCreateSprintForm` has access to the full team object with sprints.
+
+## 2. 📋 Checklist
+- [x] Step 1: Backend - Update Team Model & Create Migration
+- [x] Step 2: Backend - Update DTOs & Service Logic (Mapping, Persistence, Validation)
+- [x] Step 3: Frontend - Update Models & Team Service
+- [x] Step 4: Frontend - Update Edit Team Dialog & Create Team Form
+- [x] Step 5: Frontend - Implement Auto-fill in Sprint Creation
+- [x] Verification
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+5. **No Stealth Actions**: NEVER execute code or modify files without having first updated the plan to reflect that you are about to do so.
+
+### Step 1: Backend - Update Team Model & Create Migration
+*   **Goal:** Add `DefaultSprintDuration` to the database schema.
+*   **Action:**
+    *   Modify `api/NikoNiko.Core/Models/Team.cs`: Added `public int? DefaultSprintDuration { get; set; }`.
+    *   Run migration command: `dotnet ef migrations add AddDefaultSprintDurationToTeam --project ../NikoNiko.Data --startup-project .`.
+*   **Verification:** Migration applied.
+
+### Step 2: Backend - Update DTOs & Service Logic
+*   **Goal:** Expose and allow updating of the new field via API.
+*   **Action:**
+    *   Modify `api/NikoNiko.Core/DTOs/Team/TeamDto.cs`: Added `DefaultSprintDuration`.
+    *   Modify `api/NikoNiko.Core/DTOs/Team/UpdateTeamDto.cs`: Added `DefaultSprintDuration`.
+    *   Modify `api/NikoNiko.Core/DTOs/Team/CreateTeamDto.cs`: Added `DefaultSprintDuration`.
+    *   Modify `api/NikoNiko.Services/TeamService.cs`: Updated mapping (including `GetTeamByIdAsync` and `CreateTeamAsync`) and persistence.
+    *   Modify `api/NikoNiko.Api/Validators/Team/*.cs`: Added validation (`> 0`).
+*   **Verification:** Backend tests passed (60 tests).
+
+### Step 3: Frontend - Update Models & Team Service
+*   **Goal:** Update frontend types and service to handle the new field.
+*   **Action:**
+    *   Modify `app/frontend/src/models/Team.ts`: Added `defaultSprintDuration`.
+    *   Modify `app/frontend/src/models/CreateTeam.ts`: Added `defaultSprintDuration`.
+    *   Modify `app/frontend/src/services/teamService.ts`: Updated `updateTeam` signature.
+*   **Verification:** Compilation passed.
+
+### Step 4: Frontend - Update Edit Team Dialog & Create Team Form
+*   **Goal:** Allow admins to set the default sprint duration.
+*   **Action:**
+    *   Modify `app/frontend/src/components/EditTeamDialog.tsx`: Added input field.
+    *   Modify `app/frontend/src/components/CreateTeamForm.tsx`: Added input field.
+    *   Updated `en.json` and `fr.json` translations (including validation errors).
+*   **Verification:** Forms updated and localized.
+
+### Step 5: Frontend - Implement Auto-fill in Sprint Creation
+*   **Goal:** Auto-fill start and end dates when creating a sprint.
+*   **Action:**
+    *   Modify `app/frontend/src/components/AdminCreateSprintForm.tsx`: Implemented logic in `handleTeamChange`.
+*   **Verification:** Build passed.
+
+## 4. 🧪 Testing Strategy
+*   **Manual Verification:**
+    1.  Go to **Admin > Teams**.
+    2.  Edit a team, set "Default Sprint Duration" to **14** days. Save.
+    3.  Go to **Admin > Sprints**.
+    4.  Click "Create Sprint".
+    5.  Select the edited team.
+    6.  **Check:** Start Date should be (Last Sprint End + 1 day) or Today.
+    7.  **Check:** End Date should be (Start Date + 14 days).
+    8.  Change the team back to one without default duration.
+    9.  **Check:** End Date should not be auto-filled (or stick to previous logic).
+
+## 5. ✅ Success Criteria
+*   Team Admin can save a default sprint duration.
+*   Creating a sprint automatically suggests logical Start and End dates based on history and configuration.
+*   No regression in existing team editing or sprint creation.
+
+# Status: Completed
+All steps executed.
+- Creation flow supported.
+- Validation added (backend rules + frontend error display).
+- Localization (EN/FR) completed.
+- Mapping fixes in TeamService completed.
+- Lint and Format passed for both Backend and Frontend.
+- Backend integration tests passed.
+- Frontend production build passed.


### PR DESCRIPTION
## Summary
This Pull Request introduces the ability for Team Admins to configure a default duration for their sprints (e.g., 14 days). This setting is utilized to automatically pre-fill the start and end dates when creating a new sprint, streamlining the workflow and ensuring consistency across sprints.

## Key Changes
- 🗄️ **Backend (Core/Data/Services)**:
    - Added `DefaultSprintDuration` (nullable int) to the `Team` entity and created the corresponding EF Core migration (`AddDefaultSprintDurationToTeam`).
    - Updated `CreateTeamDto`, `UpdateTeamDto`, and `TeamDto` to include the new property.
    - Updated `TeamService` to map, persist, and retrieve the default duration.
    - Added validation logic ensuring the duration is greater than 0 if specified.
    - Added integration tests covering team creation and updates with the new property.

- 🖥️ **Frontend**:
    - Updated `Team` and `CreateTeam` models to support `defaultSprintDuration`.
    - Enhanced `EditTeamDialog` and `CreateTeamForm` to include a numeric input for the default duration.
    - Updated `AdminCreateSprintForm` to automatically calculate:
        - **Start Date**: The day after the last sprint ends (or today if no sprints exist).
        - **End Date**: The start date plus the team's default duration (if configured).
    - Moved auto-fill logic into the `handleTeamChange` event to adhere to React hooks best practices (avoiding `setState` in `useEffect`).

- 🌐 **Localization**:
    - Added English and French translations for the new field labels and validation error messages.

## Checklist
- [x] Tests passed (Backend Integration Tests)
- [x] Documentation updated (Translation files)
- [x] Frontend Build passed


Closes #34