### PR TITLE
feat(teams): allow all users to create teams with a quota of 2 teams

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,6 +27,9 @@ FRONTEND_REDIRECT_URL=http://localhost:3000
 # ASP.NET Core Environment (e.g., Development, Staging, Production)
 ASPNETCORE_ENVIRONMENT=Development
 
+# Maximum number of teams a regular user can create
+MAX_TEAMS_PER_USER=2
+
 # URL de redirection (Developpement)
 Authentication__GitHub__CallbackRedirectUri=http://localhost:5000/signin-github
 

--- a/api/NikoNiko.Api.IntegrationTests/TeamsControllerTests.cs
+++ b/api/NikoNiko.Api.IntegrationTests/TeamsControllerTests.cs
@@ -24,18 +24,64 @@ namespace NikoNiko.Api.IntegrationTests;
 public class TeamsControllerTests
 {
     [Fact]
-    public async Task CreateTeam_AsRegularUser_ReturnsForbidden()
+    public async Task CreateTeam_AsRegularUser_ReturnsCreated()
     {
         // Arrange
         await using var application = new NikoNikoApiTestApplication();
-        var (_, client, _) = await application.CreateUserAndClient("New Team Admin");
+        var (user, client, _) = await application.CreateUserAndClient("New Team Admin");
         var createTeamDto = new CreateTeamDto { Name = "My New Team" };
 
         // Act
         var response = await client.PostAsJsonAsync("/api/teams", createTeamDto);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var team = await response.Content.ReadFromJsonAsync<TeamDto>();
+        Assert.NotNull(team);
+        Assert.Equal("My New Team", team.Name);
+        Assert.Equal(user.Id, team.AdminId);
+    }
+
+    [Fact]
+    public async Task CreateTeam_WhenAtLimit_ReturnsBadRequest()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Limited User");
+        
+        // Create 2 teams first (the limit is 2)
+        await application.CreateTeam("Team 1", user.Id);
+        await application.CreateTeam("Team 2", user.Id);
+        
+        var createTeamDto = new CreateTeamDto { Name = "Third Team" };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/teams", createTeamDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var message = await response.Content.ReadAsStringAsync();
+        Assert.Contains("maximum number of teams", message);
+    }
+
+    [Fact]
+    public async Task CreateTeam_AsSuperAdmin_AllowsBypassingLimit()
+    {
+        // Arrange
+        await using var application = new NikoNikoApiTestApplication();
+        var (user, client, _) = await application.CreateUserAndClient("Super Admin", isSuperAdmin: true);
+        
+        // Create 2 teams first
+        await application.CreateTeam("Team 1", user.Id);
+        await application.CreateTeam("Team 2", user.Id);
+        
+        var createTeamDto = new CreateTeamDto { Name = "Third Team" };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/teams", createTeamDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
     [Fact]

--- a/api/NikoNiko.Api/Controllers/TeamsController.cs
+++ b/api/NikoNiko.Api/Controllers/TeamsController.cs
@@ -136,10 +136,9 @@ public class TeamsController : ControllerBase
     }
 
     /// <summary>
-    /// Creates a new team. Accessible only by a Super-admin.
+    /// Creates a new team.
     /// </summary>
     [HttpPost]
-    [Authorize(Policy = "SuperAdmin")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -151,8 +150,17 @@ public class TeamsController : ControllerBase
             return Unauthorized("User ID not found or invalid.");
         }
 
-        var teamDto = await _teamService.CreateTeamAsync(createTeamDto, userId);
-        return CreatedAtAction(nameof(GetTeam), new { teamId = teamDto.Id }, teamDto);
+        var isSuperAdmin = User.HasClaim("is_super_admin", "true");
+
+        try
+        {
+            var teamDto = await _teamService.CreateTeamAsync(createTeamDto, userId, isSuperAdmin);
+            return CreatedAtAction(nameof(GetTeam), new { teamId = teamDto.Id }, teamDto);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     /// <summary>

--- a/api/NikoNiko.Api/appsettings.json
+++ b/api/NikoNiko.Api/appsettings.json
@@ -11,6 +11,7 @@
     }
   },
   "AllowedHosts": "*",
+  "MAX_TEAMS_PER_USER": 2,
   "Authentication": {
     "Jwt": {
       "Issuer": "NikoNiko",

--- a/api/NikoNiko.Core/Interfaces/ITeamService.cs
+++ b/api/NikoNiko.Core/Interfaces/ITeamService.cs
@@ -7,7 +7,7 @@ public interface ITeamService
 {
     Task<IEnumerable<TeamWithSprintsDto>> GetTeamsAsync(Guid userId, bool isSuperAdmin);
     Task<TeamWithSprintsDto?> GetTeamByIdAsync(Guid teamId);
-    Task<TeamDto> CreateTeamAsync(CreateTeamDto createTeamDto, Guid adminId);
+    Task<TeamDto> CreateTeamAsync(CreateTeamDto createTeamDto, Guid adminId, bool isSuperAdmin);
     Task UpdateTeamAsync(Guid teamId, UpdateTeamDto updateTeamDto);
     Task TransferAdminAsync(Guid teamId, Guid newAdminId);
     Task DeleteTeamAsync(Guid teamId);

--- a/api/NikoNiko.Services/TeamService.cs
+++ b/api/NikoNiko.Services/TeamService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 using NikoNiko.Core.DTOs.Sprint;
@@ -15,12 +16,14 @@ public class TeamService : ITeamService
     private readonly ApplicationDbContext _context;
     private readonly ILogger<TeamService> _logger;
     private readonly INotificationService _notificationService;
+    private readonly IConfiguration _configuration;
 
-    public TeamService(ApplicationDbContext context, ILogger<TeamService> logger, INotificationService notificationService)
+    public TeamService(ApplicationDbContext context, ILogger<TeamService> logger, INotificationService notificationService, IConfiguration configuration)
     {
         _context = context;
         _logger = logger;
         _notificationService = notificationService;
+        _configuration = configuration;
     }
 
     public async Task<IEnumerable<TeamWithSprintsDto>> GetTeamsAsync(Guid userId, bool isSuperAdmin)
@@ -100,8 +103,23 @@ public class TeamService : ITeamService
             .FirstOrDefaultAsync(t => t.Id == teamId);
     }
 
-    public async Task<TeamDto> CreateTeamAsync(CreateTeamDto createTeamDto, Guid adminId)
+    public async Task<TeamDto> CreateTeamAsync(CreateTeamDto createTeamDto, Guid adminId, bool isSuperAdmin)
     {
+        if (!isSuperAdmin)
+        {
+            var maxTeamsConfig = _configuration["MAX_TEAMS_PER_USER"];
+            if (!int.TryParse(maxTeamsConfig, out var maxTeams))
+            {
+                maxTeams = 2; // Default if not configured
+            }
+            var currentTeamsCount = await _context.Teams.CountAsync(t => t.AdminId == adminId);
+
+            if (currentTeamsCount >= maxTeams)
+            {
+                throw new InvalidOperationException($"You have reached the maximum number of teams ({maxTeams}).");
+            }
+        }
+
         var team = new Team
         {
             Name = createTeamDto.Name,

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -105,7 +105,7 @@ function App() {
               <Route
                 path="/admin/teams"
                 element={
-                  <ProtectedRoute requiredAnyAdmin={true}>
+                  <ProtectedRoute>
                     <AdminTeamsPage />
                   </ProtectedRoute>
                 }

--- a/app/frontend/src/components/layout/Sidebar.tsx
+++ b/app/frontend/src/components/layout/Sidebar.tsx
@@ -60,15 +60,14 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ open, handleDrawerClose, handleDrawerOpen }) => {
-  const { user, logout, isSuperAdmin, userTeamRoles } = useAuth();
+  const { user, logout } = useAuth();
   const { toggleColorMode, mode } = useColorMode();
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
 
   const repoUrl = import.meta.env.VITE_GITHUB_REPO_URL;
 
-  const isAnyTeamAdmin = Object.values(userTeamRoles).some((role) => role.isAdmin);
-  const showAdminMenu = isSuperAdmin || isAnyTeamAdmin;
+  const showAdminMenu = !!user; // Show Admin menu to everyone so they can access "Teams"
 
   const [openAdminMenu, setOpenAdminMenu] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -206,30 +205,28 @@ const Sidebar: React.FC<SidebarProps> = ({ open, handleDrawerClose, handleDrawer
               </ListItemButton>
               <Collapse in={openAdminMenu} timeout="auto" unmountOnExit>
                 <List component="div" disablePadding>
-                  {(isSuperAdmin || isAnyTeamAdmin) && (
-                    <ListItem disablePadding sx={{ display: 'block' }}>
-                      <ListItemButton
-                        component={NavLink}
-                        to="/admin/teams"
+                  <ListItem disablePadding sx={{ display: 'block' }}>
+                    <ListItemButton
+                      component={NavLink}
+                      to="/admin/teams"
+                      sx={{
+                        minHeight: 48,
+                        justifyContent: open ? 'initial' : 'center',
+                        px: open ? 4.5 : 2.5, // Indent for sub-items
+                      }}
+                    >
+                      <ListItemIcon
                         sx={{
-                          minHeight: 48,
-                          justifyContent: open ? 'initial' : 'center',
-                          px: open ? 4.5 : 2.5, // Indent for sub-items
+                          minWidth: 0,
+                          mr: open ? 3 : 'auto',
+                          justifyContent: 'center',
                         }}
                       >
-                        <ListItemIcon
-                          sx={{
-                            minWidth: 0,
-                            mr: open ? 3 : 'auto',
-                            justifyContent: 'center',
-                          }}
-                        >
-                          <GroupWorkIcon />
-                        </ListItemIcon>
-                        <ListItemText primary={t('sidebar.teams')} sx={{ opacity: open ? 1 : 0 }} />
-                      </ListItemButton>
-                    </ListItem>
-                  )}
+                        <GroupWorkIcon />
+                      </ListItemIcon>
+                      <ListItemText primary={t('sidebar.teams')} sx={{ opacity: open ? 1 : 0 }} />
+                    </ListItemButton>
+                  </ListItem>
 
                   <ListItem disablePadding sx={{ display: 'block' }}>
                     <ListItemButton

--- a/app/frontend/src/i18n/locales/en.json
+++ b/app/frontend/src/i18n/locales/en.json
@@ -92,6 +92,7 @@
   "adminTeams": {
     "title": "Admin Teams",
     "createNew": "Create New Team",
+    "quotaReached": "You have reached the maximum number of teams (2). You cannot create more teams.",
     "manageAll": "Manage All Teams",
     "noTeamsFound": "No teams found.",
     "deleteFailed": "Failed to delete team.",

--- a/app/frontend/src/i18n/locales/fr.json
+++ b/app/frontend/src/i18n/locales/fr.json
@@ -92,6 +92,7 @@
   "adminTeams": {
     "title": "Administration des Équipes",
     "createNew": "Créer une nouvelle équipe",
+    "quotaReached": "Vous avez atteint le nombre maximum d'équipes (2). Vous ne pouvez pas créer plus d'équipes.",
     "manageAll": "Gérer toutes les équipes",
     "noTeamsFound": "Aucune équipe trouvée.",
     "deleteFailed": "Échec de la suppression de l'équipe.",

--- a/app/frontend/src/pages/AdminTeamsPage.tsx
+++ b/app/frontend/src/pages/AdminTeamsPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import GroupWorkIcon from '@mui/icons-material/GroupWork';
-import { Box, CircularProgress, Divider, Typography } from '@mui/material';
+import { Alert, Box, CircularProgress, Divider, Typography } from '@mui/material';
 import { useSnackbar } from 'notistack';
 
 import { useAuth } from '@/context/AuthContext';
@@ -15,13 +15,16 @@ import PageContainer from '@/components/layout/PageContainer';
 
 const AdminTeamsPage: React.FC = () => {
   const { t } = useTranslation();
-  const { isSuperAdmin } = useAuth();
+  const { user, isSuperAdmin } = useAuth();
   const { teams, isLoading, isError, mutate } = useTeams();
   const { enqueueSnackbar } = useSnackbar();
 
   const handleTeamUpdated = () => {
     mutate();
   };
+
+  const adminedTeamsCount = teams?.filter((t) => t.adminId === user?.sub).length || 0;
+  const canCreateTeam = isSuperAdmin || adminedTeamsCount < 2;
 
   const handleDeleteTeam = async (teamId: string) => {
     try {
@@ -34,13 +37,17 @@ const AdminTeamsPage: React.FC = () => {
 
   return (
     <PageContainer title={t('adminTeams.title')} icon={<GroupWorkIcon />}>
-      {isSuperAdmin && (
+      {canCreateTeam ? (
         <Box sx={{ mb: 4 }}>
           <Typography variant="h5" component="h2" gutterBottom>
             {t('adminTeams.createNew')}
           </Typography>
           <CreateTeamForm onTeamCreated={handleTeamUpdated} />
         </Box>
+      ) : (
+        <Alert severity="info" sx={{ mb: 4 }}>
+          {t('adminTeams.quotaReached')}
+        </Alert>
       )}
 
       <Divider sx={{ my: 4 }} />

--- a/plans/20260308-2159--team-creation-limit.md
+++ b/plans/20260308-2159--team-creation-limit.md
@@ -1,0 +1,110 @@
+# Implementation Plan - Limit Team Creation to 2 per Regular User
+
+Fixes issue #85 and implements a team creation quota (SaaS-like restriction). Regular users are restricted to being administrators of a maximum of 2 teams. SuperAdmins bypass this restriction.
+
+## 1. 🔍 Analysis & Context
+*   **Objective:** Allow regular users to create teams while preventing them from owning more than 2 teams. This preventsorphaned teams and controls growth.
+*   **Affected Files:**
+    *   Backend: `api/NikoNiko.Api/Controllers/TeamsController.cs`, `api/NikoNiko.Services/TeamService.cs`, `api/NikoNiko.Core/Interfaces/ITeamService.cs`, `api/NikoNiko.Api/appsettings.json`, `api/NikoNiko.Api.IntegrationTests/TeamsControllerTests.cs`
+    *   Frontend: `app/frontend/src/App.tsx`, `app/frontend/src/components/layout/Sidebar.tsx`, `app/frontend/src/pages/AdminTeamsPage.tsx`
+*   **Key Dependencies:** ASP.NET Core Configuration, Authorization Policies, React Router, Material UI.
+*   **Risks/Unknowns:** Ensure users invited to join teams are not blocked from creating their own teams as long as they aren't the administrator of more than the limit. Membership doesn't count, only ownership (`AdminId`).
+
+## 2. 📋 Checklist
+- [x] Step 1: Add Configuration for Team Limit (Backend)
+- [x] Step 2: Implement Team Limit Enforcement in Service (Backend)
+- [x] Step 3: Remove SuperAdmin restriction and handle exception in Controller (Backend)
+- [x] Step 4: Add Integration Tests for the Limit (Backend)
+- [x] Step 5: Update Route Permissions (Frontend)
+- [x] Step 6: Update Sidebar Visibility (Frontend)
+- [x] Step 7: Show Limit Message in AdminTeamsPage (Frontend)
+- [x] Verification
+
+## 3. 📝 Step-by-Step Implementation Details
+
+### 🚀 Execution Rules
+1. **Interactive Flow**: Execute ONLY ONE step at a time.
+2. **Atomic Updates**: Before and after each step, you MUST use `replace` to update the checklist in section 2 and the status in section 3.
+3. **Status Vocabulary**: Use `[x]` (Done), `[>]` (In Progress), `[-]` (Skipped/N.A.), `[!]` (Failed/Blocked).
+4. **User Confirmation**: After updating the file, stop and wait for explicit user confirmation before proceeding to the next step.
+5. **No Stealth Actions**: NEVER execute code or modify files without having first updated the plan to reflect that you are about to do so.
+
+### Step 1: Add Configuration for Team Limit (Backend) [x]
+*   **Goal:** Provide a configurable limit for team creation.
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/appsettings.json`: Add `"MAX_TEAMS_PER_USER": 2` under a configuration section.
+*   **Verification:** Confirm the value exists in the configuration file.
+
+### Step 2: Implement Team Limit Enforcement in Service (Backend) [x]
+*   **Goal:** Ensure `CreateTeamAsync` counts the number of teams the user already admins.
+*   **Action:**
+    *   Modify `api/NikoNiko.Core/Interfaces/ITeamService.cs`: Add `bool isSuperAdmin` parameter to `CreateTeamAsync`.
+    *   Modify `api/NikoNiko.Services/TeamService.cs`:
+        *   Inject `IConfiguration`.
+        *   In `CreateTeamAsync`, if `!isSuperAdmin`, count `_context.Teams.CountAsync(t => t.AdminId == adminId)`.
+        *   If the count is >= limit, throw an `InvalidOperationException` with a clear message like "You have reached the maximum number of teams (2).".
+*   **Verification:** The API project should compile after these changes.
+
+### Step 3: Remove SuperAdmin restriction and handle exception in Controller (Backend) [x]
+*   **Goal:** Allow all users to call the endpoint and handle the limit error.
+*   **Action:**
+    *   Modify `api/NikoNiko.Api/Controllers/TeamsController.cs`:
+        *   Remove `[Authorize(Policy = "SuperAdmin")]` from `CreateTeam`.
+        *   Pass `isSuperAdmin` claim to `_teamService.CreateTeamAsync`.
+        *   Catch `InvalidOperationException` and return `BadRequest(ex.Message)`.
+*   **Verification:** Rebuild the API project.
+
+### Step 4: Add Integration Tests for the Limit (Backend) [x]
+*   **Goal:** Verify the limit is respected for regular users and ignored for SuperAdmins.
+*   **Action:**
+    *   Modify `api/NikoNiko.Api.IntegrationTests/TeamsControllerTests.cs`:
+        *   Change `CreateTeam_AsRegularUser_ReturnsForbidden` to `CreateTeam_AsRegularUser_ReturnsCreated`.
+        *   Update the assertion from `HttpStatusCode.Forbidden` to `HttpStatusCode.Created`.
+        *   Verify the created team properties.
+*   **Verification:** Run the integration tests: `dotnet test api/NikoNiko.Api.IntegrationTests/NikoNiko.Api.IntegrationTests.csproj --filter FullyQualifiedName~TeamsControllerTests`.
+
+### Step 5: Update Route Permissions (Frontend) [x]
+*   **Goal:** Allow non-admins to access the `/admin/teams` route.
+*   **Action:**
+    *   Modify `app/frontend/src/App.tsx`: Remove `requiredAnyAdmin={true}` from the `ProtectedRoute` wrapping `AdminTeamsPage`.
+*   **Verification:** Attempt to navigate to `/admin/teams` as a non-admin user.
+
+### Step 6: Update Sidebar Visibility (Frontend) [x]
+*   **Goal:** Ensure the "Admin" menu and "Teams" link are visible to all users.
+*   **Action:**
+    *   Modify `app/frontend/src/components/layout/Sidebar.tsx`:
+        *   Update `showAdminMenu` logic to be `true` for any authenticated user (`const showAdminMenu = !!user;`).
+        *   Ensure the "Teams" sub-item is visible without the `isSuperAdmin || isAnyTeamAdmin` check.
+*   **Verification:** Log in as a non-admin user and check if the sidebar shows the "Admin" menu and "Teams" link.
+
+### Step 7: Show Limit Message in AdminTeamsPage (Frontend) [>]
+*   **Goal:** Inform the user when the limit is reached and hide the creation form.
+*   **Action:**
+    *   Modify `app/frontend/src/pages/AdminTeamsPage.tsx`:
+        *   Count the number of teams the user is an admin of: `const adminedTeamsCount = teams?.filter(t => t.adminId === user?.sub).length || 0;`.
+        *   If `adminedTeamsCount >= 2` and `!isSuperAdmin`, show an informative `Alert` message and hide `CreateTeamForm`.
+*   **Verification:** Visit `/admin/teams` as a user with 2 teams and verify the message is shown.
+
+### Verification [x]
+*   **Goal:** Ensure the entire feature works correctly and is properly internationalized.
+*   **Action:**
+    *   Backend: Run integration tests (`TeamsControllerTests`).
+    *   Frontend: Run `npm run build` to check for compilation errors.
+    *   I18n: Add `adminTeams.quotaReached` to `en.json` and `fr.json`.
+*   **Verification:** All tests passed, frontend build is successful, and translations are correctly applied.
+
+## 4. 🧪 Testing Strategy
+*   **Unit Tests:** N/A (Service logic covered by Integration tests).
+*   **Integration Tests:**
+    *   Run `TeamsControllerTests` to verify limit enforcement and SuperAdmin bypass.
+*   **Manual Verification:**
+    1.  Login as a user with no teams (e.g., a new invitee).
+    2.  Create 2 teams successfully.
+    3.  Try to create a 3rd team via the UI (form should be hidden) and verify the limit message.
+    4.  Verify a SuperAdmin can create more than 2 teams.
+
+## 5. ✅ Success Criteria
+*   Regular users can create their own teams but are capped at 2 owned teams.
+*   SuperAdmins are not subject to this cap.
+*   The UI provides clear feedback to the user when the quota is reached.
+*   Users invited to other teams are not penalized in their own creation quota.


### PR DESCRIPTION
## Summary
This PR enables all authenticated users to create their own teams, resolving a limitation where invited users without an initial team were unable to create one. To prevent uncontrolled team proliferation, a configurable quota of 2 owned teams per regular user has been implemented. SuperAdmins are exempt from this limit. 🚀

## Key Changes
- **Backend** ⚙️:
    - Removed `SuperAdmin` policy requirement from the team creation endpoint in `TeamsController`.
    - Implemented team ownership counting and quota enforcement in `TeamService`.
    - Added `MAX_TEAMS_PER_USER` configuration (defaulting to 2) in `appsettings.json`, `.env.template`, and `.env`.
    - Updated `ITeamService` interface to support passing `isSuperAdmin` status during creation.
- **Frontend** 🎨:
    - Updated routing in `App.tsx` to allow all authenticated users to access the Teams management page.
    - Modified `Sidebar.tsx` to make the "Admin" menu and "Teams" link visible to all users.
    - Updated `AdminTeamsPage.tsx` to show a "Quota Reached" alert and hide the creation form when a user reaches their limit.
    - Added internationalized strings for the quota alert in English and French.
- **Testing** 🧪:
    - Updated `TeamsControllerTests.cs` to verify that regular users can create teams.
    - Added new integration tests to ensure the quota is respected for regular users and bypassed by SuperAdmins.

## Checklist
- [x] Tests passed
- [x] Documentation updated

---

Closes #85